### PR TITLE
Add Dirshu Amud HaYomi daily learning program

### DIFF
--- a/src/DafPageEvent.ts
+++ b/src/DafPageEvent.ts
@@ -3,7 +3,7 @@ import {Event} from '@hebcal/core/dist/esm/event';
 import {DafPage} from './DafPage';
 import './locale';
 
-const dafYomiSefaria: Record<string, string> = {
+export const dafYomiSefaria: Record<string, string> = {
   Berachot: 'Berakhot',
   'Rosh Hashana': 'Rosh Hashanah',
   Gitin: 'Gittin',

--- a/src/DirshuAmudYomiEvent.ts
+++ b/src/DirshuAmudYomiEvent.ts
@@ -1,0 +1,57 @@
+import {Locale} from '@hebcal/core/dist/esm/locale';
+import {HDate} from '@hebcal/hdate';
+import {flags} from '@hebcal/core/dist/esm/event';
+import {DafPageEvent} from './DafPageEvent';
+import {DirshuAmudYomi, calculateDirshuAmud} from './dirshuAmudYomiBase';
+import './locale';
+
+const sefariaNames: Record<string, string> = {
+  Berachot: 'Berakhot',
+  'Rosh Hashana': 'Rosh_Hashanah',
+  Gitin: 'Gittin',
+  'Baba Kamma': 'Bava_Kamma',
+  'Baba Metzia': 'Bava_Metzia',
+  'Baba Batra': 'Bava_Batra',
+  Bechorot: 'Bekhorot',
+  Arachin: 'Arakhin',
+  Midot: 'Middot',
+} as const;
+
+/**
+ * Event wrapper around a Dirshu Amud HaYomi result
+ */
+export class DirshuAmudYomiEvent extends DafPageEvent {
+  constructor(date: HDate) {
+    const daf = calculateDirshuAmud(date.greg());
+    super(date, daf, flags.DAILY_LEARNING);
+    this.category = 'Dirshu Amud HaYomi';
+  }
+
+  /**
+   * Returns the name with "Dirshu Amud HaYomi: " prefix (e.g. "Dirshu Amud HaYomi: Shekalim 4b").
+   * @param [locale] Optional locale name (defaults to active locale).
+   */
+  render(locale?: string): string {
+    return (
+      Locale.gettext('Dirshu Amud HaYomi', locale) +
+      ': ' +
+      this.daf.render(locale)
+    );
+  }
+
+  /**
+   * Returns a link to sefaria.org
+   */
+  url(): string {
+    const daf = this.daf as DirshuAmudYomi;
+    const tractate = daf.getName();
+    const blattNum = daf.blattNum;
+    const side = daf.side;
+    const name0 = sefariaNames[tractate] || tractate.replace(/ /g, '_');
+    return `https://www.sefaria.org/${name0}.${blattNum}${side}?lang=bi`;
+  }
+
+  getCategories(): string[] {
+    return ['dirshuAmudYomi'];
+  }
+}

--- a/src/DirshuAmudYomiEvent.ts
+++ b/src/DirshuAmudYomiEvent.ts
@@ -9,7 +9,7 @@ import {DirshuAmudYomi, calculateDirshuAmud} from './dirshuAmudYomiBase';
  */
 export class DirshuAmudYomiEvent extends DafPageEvent {
   constructor(date: HDate) {
-    const daf = calculateDirshuAmud(date.greg());
+    const daf = calculateDirshuAmud(date);
     super(date, daf, flags.DAILY_LEARNING);
     this.category = 'Dirshu Amud HaYomi';
   }
@@ -34,8 +34,8 @@ export class DirshuAmudYomiEvent extends DafPageEvent {
     const tractate = daf.getName();
     // dafYomiSefaria maps Shekalim to the Yerushalmi page, but Dirshu uses Bavli
     const name0 =
-      tractate === 'Shekalim' ? tractate : (dafYomiSefaria[tractate] || tractate);
-    const name = name0.replace(/ /g, '_');
+      tractate === 'Shekalim' ? tractate : dafYomiSefaria[tractate] || tractate;
+    const name = name0.replaceAll(' ', '_');
     return `https://www.sefaria.org/${name}.${daf.blattNum}${daf.side}?lang=bi`;
   }
 

--- a/src/DirshuAmudYomiEvent.ts
+++ b/src/DirshuAmudYomiEvent.ts
@@ -1,21 +1,8 @@
 import {Locale} from '@hebcal/core/dist/esm/locale';
 import {HDate} from '@hebcal/hdate';
 import {flags} from '@hebcal/core/dist/esm/event';
-import {DafPageEvent} from './DafPageEvent';
+import {DafPageEvent, dafYomiSefaria} from './DafPageEvent';
 import {DirshuAmudYomi, calculateDirshuAmud} from './dirshuAmudYomiBase';
-import './locale';
-
-const sefariaNames: Record<string, string> = {
-  Berachot: 'Berakhot',
-  'Rosh Hashana': 'Rosh_Hashanah',
-  Gitin: 'Gittin',
-  'Baba Kamma': 'Bava_Kamma',
-  'Baba Metzia': 'Bava_Metzia',
-  'Baba Batra': 'Bava_Batra',
-  Bechorot: 'Bekhorot',
-  Arachin: 'Arakhin',
-  Midot: 'Middot',
-} as const;
 
 /**
  * Event wrapper around a Dirshu Amud HaYomi result
@@ -45,10 +32,11 @@ export class DirshuAmudYomiEvent extends DafPageEvent {
   url(): string {
     const daf = this.daf as DirshuAmudYomi;
     const tractate = daf.getName();
-    const blattNum = daf.blattNum;
-    const side = daf.side;
-    const name0 = sefariaNames[tractate] || tractate.replace(/ /g, '_');
-    return `https://www.sefaria.org/${name0}.${blattNum}${side}?lang=bi`;
+    // dafYomiSefaria maps Shekalim to the Yerushalmi page, but Dirshu uses Bavli
+    const name0 =
+      tractate === 'Shekalim' ? tractate : (dafYomiSefaria[tractate] || tractate);
+    const name = name0.replace(/ /g, '_');
+    return `https://www.sefaria.org/${name}.${daf.blattNum}${daf.side}?lang=bi`;
   }
 
   getCategories(): string[] {

--- a/src/dirshuAmudYomi.ts
+++ b/src/dirshuAmudYomi.ts
@@ -11,4 +11,8 @@ function wrapper(hd: HDate): DirshuAmudYomiEvent | null {
   return new DirshuAmudYomiEvent(hd);
 }
 
-DailyLearning.addCalendar('dirshuAmudYomi', wrapper, new HDate(dirshuAmudYomiStart));
+DailyLearning.addCalendar(
+  'dirshuAmudYomi',
+  wrapper,
+  new HDate(dirshuAmudYomiStart)
+);

--- a/src/dirshuAmudYomi.ts
+++ b/src/dirshuAmudYomi.ts
@@ -1,0 +1,14 @@
+import {HDate} from '@hebcal/hdate';
+import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+import {dirshuAmudYomiStart} from './dirshuAmudYomiBase';
+import {DirshuAmudYomiEvent} from './DirshuAmudYomiEvent';
+
+function wrapper(hd: HDate): DirshuAmudYomiEvent | null {
+  const abs = hd.abs();
+  if (abs < dirshuAmudYomiStart) {
+    return null;
+  }
+  return new DirshuAmudYomiEvent(hd);
+}
+
+DailyLearning.addCalendar('dirshuAmudYomi', wrapper, new HDate(dirshuAmudYomiStart));

--- a/src/dirshuAmudYomiBase.ts
+++ b/src/dirshuAmudYomiBase.ts
@@ -1,0 +1,116 @@
+import {HDate, greg, gematriya} from '@hebcal/hdate';
+import {Locale} from '@hebcal/core/dist/esm/locale';
+import {DafPage} from './DafPage';
+import {checkTooEarly, getAbsDate} from './common';
+import './locale';
+
+// Cycle began on 1 Cheshvan 5784 = October 16, 2023
+const startDate = new Date(2023, 9, 16);
+export const dirshuAmudYomiStart = greg.greg2abs(startDate);
+
+type AmudEntry = {
+  name: string;
+  amudim: number;
+};
+
+export const shas: AmudEntry[] = (
+  [
+    ['Berachot', 125],
+    ['Shabbat', 312],
+    ['Eruvin', 207],
+    ['Pesachim', 240],
+    ['Shekalim', 42], // Bavli edition
+    ['Yoma', 173],
+    ['Sukkah', 110],
+    ['Beitzah', 78],
+    ['Rosh Hashana', 68],
+    ['Taanit', 59],
+    ['Megillah', 61],
+    ['Moed Katan', 55],
+    ['Chagigah', 51],
+    ['Yevamot', 242],
+    ['Ketubot', 222],
+    ['Nedarim', 180],
+    ['Nazir', 130],
+    ['Sotah', 96],
+    ['Gitin', 178],
+    ['Kiddushin', 162],
+    ['Baba Kamma', 236],
+    ['Baba Metzia', 235],
+    ['Baba Batra', 350],
+    ['Sanhedrin', 224],
+    ['Makkot', 46],
+    ['Shevuot', 96],
+    ['Avodah Zarah', 150],
+    ['Horayot', 25],
+    ['Zevachim', 238],
+    ['Menachot', 217],
+    ['Chullin', 281],
+    ['Bechorot', 119],
+    ['Arachin', 65],
+    ['Temurah', 65],
+    ['Keritot', 54],
+    ['Meilah', 41],
+    ['Kinnim', 6],
+    ['Tamid', 17],
+    ['Midot', 8],
+    ['Niddah', 143],
+  ] as [string, number][]
+).map(m => ({name: m[0], amudim: m[1]}));
+
+const totalAmudim = shas.reduce((s, a) => s + a.amudim, 0);
+
+/**
+ * Represents an amud (side of a page) in the Dirshu Amud HaYomi program
+ */
+export class DirshuAmudYomi extends DafPage {
+  blattNum: number;
+  side: 'a' | 'b';
+
+  constructor(name: string, blattNum: number, side: 'a' | 'b') {
+    super(name, `${blattNum}${side}`);
+    this.blattNum = blattNum;
+    this.side = side;
+  }
+
+  /**
+   * Formats the amud as a string like "Shekalim 4b"
+   * @param [locale] Optional locale name (defaults to active locale).
+   */
+  render(locale?: string): string {
+    locale = locale || 'en';
+    if (typeof locale === 'string') {
+      locale = locale.toLowerCase();
+    }
+    const name = Locale.gettext(this.name, locale);
+    if (locale === 'he' || locale === 'he-x-nonikud') {
+      const sideStr = this.side === 'a' ? 'ע״א' : 'ע״ב';
+      return name + ' דף ' + gematriya(this.blattNum) + ' ' + sideStr;
+    }
+    return name + ' ' + this.blatt;
+  }
+}
+
+/**
+ * Calculates the Dirshu Amud HaYomi for a given date
+ * @param date - Hebrew or Gregorian date
+ */
+export function calculateDirshuAmud(
+  date: HDate | Date | number
+): DirshuAmudYomi {
+  const cday = getAbsDate(date);
+  checkTooEarly(cday, dirshuAmudYomiStart, 'Dirshu Amud HaYomi');
+  const dno = (cday - dirshuAmudYomiStart) % totalAmudim;
+
+  let total = 0;
+  for (const tractate of shas) {
+    if (dno < total + tractate.amudim) {
+      const idx = dno - total;
+      const blattNum = 2 + Math.floor(idx / 2);
+      const side: 'a' | 'b' = idx % 2 === 0 ? 'a' : 'b';
+      return new DirshuAmudYomi(tractate.name, blattNum, side);
+    }
+    total += tractate.amudim;
+  }
+  throw new Error('Internal error: Dirshu Amud HaYomi calculation failed');
+}

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,4 +1,5 @@
 import './arukhHaShulchanYomi';
+import './dirshuAmudYomi';
 import './chofetzChaim';
 import './dafWeekly';
 import './dafYomi';

--- a/test/dirshuAmudYomi.spec.ts
+++ b/test/dirshuAmudYomi.spec.ts
@@ -1,0 +1,177 @@
+import {expect, test} from 'vitest';
+import {HDate} from '@hebcal/hdate';
+import {
+  calculateDirshuAmud,
+  DirshuAmudYomi,
+  dirshuAmudYomiStart,
+  shas,
+} from '../src/dirshuAmudYomiBase';
+import {DirshuAmudYomiEvent} from '../src/DirshuAmudYomiEvent';
+
+test('cycle-start-day1', () => {
+  // Cycle began on 1 Cheshvan 5784 = October 16, 2023 = Berachot 2a
+  const dt = new Date(2023, 9, 16);
+  const amud = calculateDirshuAmud(dt);
+  expect(amud.getName()).toBe('Berachot');
+  expect(amud.blattNum).toBe(2);
+  expect(amud.side).toBe('a');
+  expect(amud.getBlatt()).toBe('2a');
+  expect(amud.render('en')).toBe('Berachot 2a');
+});
+
+test('cycle-start-day2', () => {
+  // October 17, 2023 = Berachot 2b
+  const dt = new Date(2023, 9, 17);
+  const amud = calculateDirshuAmud(dt);
+  expect(amud.getName()).toBe('Berachot');
+  expect(amud.blattNum).toBe(2);
+  expect(amud.side).toBe('b');
+  expect(amud.render('en')).toBe('Berachot 2b');
+});
+
+test('today-march-23-2026', () => {
+  // March 23, 2026 = 5 Nisan 5786 = Shekalim 4b
+  const dt = new Date(2026, 2, 23);
+  const amud = calculateDirshuAmud(dt);
+  expect(amud.getName()).toBe('Shekalim');
+  expect(amud.blattNum).toBe(4);
+  expect(amud.side).toBe('b');
+  expect(amud.render('en')).toBe('Shekalim 4b');
+});
+
+test('berachot-last-amud', () => {
+  // Berachot has 125 amudim, last is index 124 → blatt 64a
+  const amud = calculateDirshuAmud(dirshuAmudYomiStart + 124);
+  expect(amud.getName()).toBe('Berachot');
+  expect(amud.blattNum).toBe(64);
+  expect(amud.side).toBe('a');
+  expect(amud.render('en')).toBe('Berachot 64a');
+});
+
+test('shabbat-first-amud', () => {
+  // Shabbat starts on day 125 from cycle start
+  const amud = calculateDirshuAmud(dirshuAmudYomiStart + 125);
+  expect(amud.getName()).toBe('Shabbat');
+  expect(amud.blattNum).toBe(2);
+  expect(amud.side).toBe('a');
+  expect(amud.render('en')).toBe('Shabbat 2a');
+});
+
+test('shabbat-last-amud', () => {
+  // Shabbat has 312 amudim (indices 125-436), last is index 436 → blatt 157b
+  // Day 436 from cycle start
+  const startAbs = dirshuAmudYomiStart;
+  const amud = calculateDirshuAmud(startAbs + 436);
+  expect(amud.getName()).toBe('Shabbat');
+  expect(amud.blattNum).toBe(157);
+  expect(amud.side).toBe('b');
+  expect(amud.render('en')).toBe('Shabbat 157b');
+});
+
+test('cycle-boundary-wraps', () => {
+  // After the last amud of the cycle, it should wrap back to Berachot 2a
+  const totalAmudim = shas.reduce((s, a) => s + a.amudim, 0);
+  const amud = calculateDirshuAmud(dirshuAmudYomiStart + totalAmudim);
+  expect(amud.getName()).toBe('Berachot');
+  expect(amud.blattNum).toBe(2);
+  expect(amud.side).toBe('a');
+});
+
+test('niddah-last-amud', () => {
+  // Niddah is the last tractate with 143 amudim (odd), last amud = index 142 within Niddah
+  // index 142: blatt = 2 + floor(142/2) = 2 + 71 = 73, side = 142%2 = 0 → 'a'
+  const totalAmudim = shas.reduce((s, a) => s + a.amudim, 0);
+  const amud = calculateDirshuAmud(dirshuAmudYomiStart + totalAmudim - 1);
+  expect(amud.getName()).toBe('Niddah');
+  expect(amud.blattNum).toBe(73);
+  expect(amud.side).toBe('a');
+  expect(amud.render('en')).toBe('Niddah 73a');
+});
+
+test('too-early-throws', () => {
+  // Date before cycle start should throw
+  expect(() => {
+    calculateDirshuAmud(new Date(2023, 9, 15)); // October 15, 2023 (day before start)
+  }).toThrow('Date 2023-10-15 too early; Dirshu Amud HaYomi cycle began on 2023-10-16');
+});
+
+test('event-render-english', () => {
+  const hd = new HDate(new Date(2026, 2, 23)); // March 23, 2026
+  const ev = new DirshuAmudYomiEvent(hd);
+  expect(ev.render('en')).toBe('Dirshu Amud HaYomi: Shekalim 4b');
+  expect(ev.getDesc()).toBe('Shekalim 4b');
+  expect(ev.category).toBe('Dirshu Amud HaYomi');
+  expect(ev.getCategories()).toEqual(['dirshuAmudYomi']);
+});
+
+test('event-render-brief', () => {
+  const hd = new HDate(new Date(2026, 2, 23)); // March 23, 2026 = Shekalim 4b
+  const ev = new DirshuAmudYomiEvent(hd);
+  expect(ev.renderBrief('en')).toBe('Shekalim 4b');
+});
+
+test('event-render-hebrew', () => {
+  const hd = new HDate(new Date(2026, 2, 23)); // March 23, 2026 = Shekalim 4b
+  const ev = new DirshuAmudYomiEvent(hd);
+  const rendered = ev.render('he');
+  // Should include Hebrew Shekalim and the amud bet notation
+  expect(rendered).toContain('שקלים');
+  expect(rendered).toContain('ע״ב');
+});
+
+test('event-url-sefaria', () => {
+  const hd = new HDate(new Date(2026, 2, 23)); // Shekalim 4b
+  const ev = new DirshuAmudYomiEvent(hd);
+  expect(ev.url()).toBe('https://www.sefaria.org/Shekalim.4b?lang=bi');
+});
+
+test('event-url-berachot-sefaria', () => {
+  // Berachot → Berakhot on sefaria
+  const hd = new HDate(new Date(2023, 9, 16)); // October 16, 2023 = Berachot 2a
+  const ev = new DirshuAmudYomiEvent(hd);
+  expect(ev.url()).toBe('https://www.sefaria.org/Berakhot.2a?lang=bi');
+});
+
+test('event-url-rosh-hashana', () => {
+  // Rosh Hashana → Rosh_Hashanah on sefaria
+  // Find when Rosh Hashana starts
+  const beforeRH =
+    shas.slice(0, 8).reduce((s, a) => s + a.amudim, 0);
+  const hd = new HDate(dirshuAmudYomiStart + beforeRH);
+  const ev = new DirshuAmudYomiEvent(hd);
+  expect(ev.url()).toBe('https://www.sefaria.org/Rosh_Hashanah.2a?lang=bi');
+});
+
+test('event-url-bava-kamma', () => {
+  // Baba Kamma → Bava_Kamma on sefaria
+  const beforeBK =
+    shas.slice(0, 20).reduce((s, a) => s + a.amudim, 0);
+  const hd = new HDate(dirshuAmudYomiStart + beforeBK);
+  const ev = new DirshuAmudYomiEvent(hd);
+  expect(ev.url()).toBe('https://www.sefaria.org/Bava_Kamma.2a?lang=bi');
+});
+
+test('amud-render-in-middle', () => {
+  // Test a daf in the middle — Eruvin 54b
+  // Eruvin starts at index 437, 54b = daf 54 side b
+  // index within Eruvin for 54b: (54-2)*2 + 1 = 105
+  const eruvinStart = shas.slice(0, 2).reduce((s, a) => s + a.amudim, 0);
+  const amud = calculateDirshuAmud(dirshuAmudYomiStart + eruvinStart + 105);
+  expect(amud.getName()).toBe('Eruvin');
+  expect(amud.blattNum).toBe(54);
+  expect(amud.side).toBe('b');
+  expect(amud.render('en')).toBe('Eruvin 54b');
+});
+
+test('dirshu-amud-yomi-instance', () => {
+  const amud = new DirshuAmudYomi('Berachot', 2, 'a');
+  expect(amud.getName()).toBe('Berachot');
+  expect(amud.getBlatt()).toBe('2a');
+  expect(amud.blattNum).toBe(2);
+  expect(amud.side).toBe('a');
+});
+
+test('total-amudim', () => {
+  const total = shas.reduce((s, a) => s + a.amudim, 0);
+  expect(total).toBe(5407);
+});


### PR DESCRIPTION
## Summary
This PR adds support for the Dirshu Amud HaYomi daily learning program, which cycles through all 5,407 amudim (pages) of the Talmud. The cycle began on October 16, 2023 (1 Cheshvan 5784) with Berachot 2a.

## Key Changes
- **New `DirshuAmudYomi` class** (`dirshuAmudYomiBase.ts`): Extends `DafPage` to represent a specific amud in the Dirshu program with tractate name, blatt number, and side (a/b)
- **`calculateDirshuAmud()` function**: Computes which amud should be studied on a given date by calculating days elapsed since the cycle start and mapping to the appropriate tractate and page
- **`DirshuAmudYomiEvent` class** (`DirshuAmudYomiEvent.ts`): Event wrapper that integrates with the daily learning system, providing:
  - Localized rendering in English and Hebrew
  - Brief format output
  - Sefaria.org links with proper tractate name mappings (e.g., "Berachot" → "Berakhot", "Baba Kamma" → "Bava_Kamma")
  - Category classification as `dirshuAmudYomi`
- **Daily learning integration** (`dirshuAmudYomi.ts`): Registers the program with the `DailyLearning` system, making it available for calendar queries starting from the cycle start date
- **Comprehensive test suite** (`dirshuAmudYomi.spec.ts`): 177 lines of tests covering:
  - Cycle start dates and boundary conditions
  - Specific amudim calculations across different tractates
  - Cycle wrapping behavior
  - Event rendering in multiple locales
  - Sefaria URL generation with proper name mappings
  - Edge cases (too-early dates, last amud of cycle)

## Implementation Details
- The Shas (all 40 tractates) is defined as a lookup table with amud counts totaling 5,407
- Amud calculation uses modulo arithmetic to handle cycle wrapping
- Each amud maps to a blatt number starting from 2 (since daf 1 is typically not studied) with alternating a/b sides
- Hebrew rendering uses gematriya for page numbers and special notation (ע״א/ע״ב) for sides
- Sefaria name mappings handle special cases where English tractate names differ from Sefaria's URL format

https://claude.ai/code/session_016o5KhppqzAC6F68t2tRRho