### PR TITLE
Move this.alarm=false to DailyLearningEvent base class; add DirshuAmudYomi exports

### DIFF
--- a/src/ChofetzChaimEvent.ts
+++ b/src/ChofetzChaimEvent.ts
@@ -22,7 +22,6 @@ export class ChofetzChaimEvent extends DailyLearningEvent {
     super(date, desc);
     this.reading = reading;
     this.memo = this.render('memo');
-    this.alarm = false;
     this.category = 'Chofetz Chaim';
   }
   /**

--- a/src/DafWeeklyEvent.ts
+++ b/src/DafWeeklyEvent.ts
@@ -9,7 +9,6 @@ import {DafPageEvent} from './DafPageEvent';
 export class DafWeeklyEvent extends DafPageEvent {
   constructor(date: HDate, daf: DafPage) {
     super(date, daf, flags.DAILY_LEARNING);
-    this.alarm = false;
     this.category = 'Daf Weekly';
   }
   getCategories(): string[] {

--- a/src/DailyLearningEvent.ts
+++ b/src/DailyLearningEvent.ts
@@ -4,5 +4,6 @@ import {Event, flags} from '@hebcal/core/dist/esm/event';
 export class DailyLearningEvent extends Event {
   constructor(date: HDate, desc: string, mask: number = flags.DAILY_LEARNING) {
     super(date, desc, mask);
+    this.alarm = false;
   }
 }

--- a/src/DailyRambam3Event.ts
+++ b/src/DailyRambam3Event.ts
@@ -52,7 +52,6 @@ export class DailyRambam3Event extends DailyLearningEvent {
     super(date, desc);
     this.readings = collapsed;
     this.events = collapsed.map(r => new DailyRambamEvent(date, r));
-    this.alarm = false;
     this.category = 'Daily Rambam';
     if (collapsed.length > 1) {
       this.memo = this.events

--- a/src/DailyRambamEvent.ts
+++ b/src/DailyRambamEvent.ts
@@ -14,7 +14,6 @@ export class DailyRambamEvent extends DailyLearningEvent {
   constructor(date: HDate, reading: RambamReading) {
     super(date, `${reading.name} ${reading.perek}`);
     this.reading = reading;
-    this.alarm = false;
     this.category = 'Daily Rambam';
   }
   /**

--- a/src/KitzurShulchanAruchEvent.ts
+++ b/src/KitzurShulchanAruchEvent.ts
@@ -71,7 +71,6 @@ export class KitzurShulchanAruchEvent extends DailyLearningEvent {
     this.reading = reading;
     this.optionB = optionB;
     this.leapAdar2 = date.isLeapYear() && date.getMonth() === months.ADAR_II;
-    this.alarm = false;
     this.category = BOOK_NAME;
   }
   /**

--- a/src/PirkeiAvotSummerEvent.ts
+++ b/src/PirkeiAvotSummerEvent.ts
@@ -16,7 +16,6 @@ export class PirkeiAvotSummerEvent extends DailyLearningEvent {
   constructor(date: HDate, reading: number[]) {
     super(date, PIRKEI_AVOT + ' ' + reading.join('-'));
     this.reading = reading;
-    this.alarm = false;
     this.category = PIRKEI_AVOT;
   }
   /**

--- a/src/PsalmsEvent.ts
+++ b/src/PsalmsEvent.ts
@@ -14,7 +14,6 @@ export class PsalmsEvent extends DailyLearningEvent {
   constructor(date: HDate, reading: PsalmBeginEnd) {
     super(date, `Psalms ${reading[0]}-${reading[1]}`);
     this.reading = reading;
-    this.alarm = false;
     this.category = 'Psalms';
   }
   /**

--- a/src/SeferHaMitzvotEvent.ts
+++ b/src/SeferHaMitzvotEvent.ts
@@ -18,7 +18,6 @@ export class SeferHaMitzvotEvent extends DailyLearningEvent {
     const desc = `Day ${reading.day}: ${reading.reading}`;
     super(date, desc);
     this.reading = reading;
-    this.alarm = false;
     this.category = 'Sefer Hamitzvot';
     if (reading.note) {
       this.memo = reading.note;

--- a/src/ShemiratHaLashonEvent.ts
+++ b/src/ShemiratHaLashonEvent.ts
@@ -24,7 +24,6 @@ export class ShemiratHaLashonEvent extends DailyLearningEvent {
     super(date, desc);
     this.reading = reading;
     this.memo = this.render('memo');
-    this.alarm = false;
     this.category = 'Shemirat HaLashon';
   }
   /**

--- a/src/TanakhYomiEvent.ts
+++ b/src/TanakhYomiEvent.ts
@@ -9,7 +9,6 @@ import {TanakhYomi} from './tanakhYomiBase';
 export class TanakhYomiEvent extends DafPageEvent {
   constructor(date: HDate, daf: TanakhYomi) {
     super(date, daf, flags.DAILY_LEARNING);
-    this.alarm = false;
     this.category = 'Tanakh Yomi';
     this.memo = daf.verses;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,3 +45,9 @@ export {
   KitzurShulchanAruchReading,
 } from './kitzurShulchanAruchBase';
 export {KitzurShulchanAruchEvent} from './KitzurShulchanAruchEvent';
+export {
+  DirshuAmudYomi,
+  calculateDirshuAmud,
+  dirshuAmudYomiStart,
+} from './dirshuAmudYomiBase';
+export {DirshuAmudYomiEvent} from './DirshuAmudYomiEvent';


### PR DESCRIPTION
Set this.alarm = false in DailyLearningEvent constructor so all subclasses
inherit it automatically, removing the redundant assignments from 10 subclasses.

Add DirshuAmudYomi, calculateDirshuAmud, dirshuAmudYomiStart, and
DirshuAmudYomiEvent exports to index.ts following the same pattern as other
learning calendars.

https://claude.ai/code/session_014XDkQY4PVMf39HVTqw5fRS