### PR TITLE
Refactor category property to getter in daily learning events

### DIFF
--- a/src/ArukhHaShulchanYomiEvent.ts
+++ b/src/ArukhHaShulchanYomiEvent.ts
@@ -10,11 +10,12 @@ import './locale';
  */
 export class ArukhHaShulchanYomiEvent extends DailyLearningEvent {
   reading: AhSYomiReading;
-  category: string;
+  get category(): string {
+    return 'Arukh HaShulchan Yomi';
+  }
   constructor(date: HDate, reading: AhSYomiReading) {
     super(date, `${reading.k} ${reading.v}`);
     this.reading = reading;
-    this.category = 'Arukh HaShulchan Yomi';
   }
   render(locale?: string): string {
     const loc = (locale || 'en').toLowerCase();

--- a/src/ChofetzChaimEvent.ts
+++ b/src/ChofetzChaimEvent.ts
@@ -16,13 +16,14 @@ import './locale';
  */
 export class ChofetzChaimEvent extends DailyLearningEvent {
   reading: ChofetzChaimReading;
-  category: string;
+  get category(): string {
+    return 'Chofetz Chaim';
+  }
   constructor(date: HDate, reading: ChofetzChaimReading) {
     const desc = reading.k + formatReadingPages(reading);
     super(date, desc);
     this.reading = reading;
     this.memo = this.render('memo');
-    this.category = 'Chofetz Chaim';
   }
   /**
    * Returns name of reading

--- a/src/DafPageEvent.ts
+++ b/src/DafPageEvent.ts
@@ -24,7 +24,6 @@ export const dafYomiSefaria: Record<string, string> = {
  */
 export class DafPageEvent extends DailyLearningEvent {
   daf: DafPage;
-  category?: string;
   constructor(date: HDate, daf: DafPage, mask: number) {
     super(date, daf.render('en'), mask);
     this.daf = daf;

--- a/src/DafWeeklyEvent.ts
+++ b/src/DafWeeklyEvent.ts
@@ -7,9 +7,11 @@ import {DafPageEvent} from './DafPageEvent';
  * Event wrapper around a daily weekly
  */
 export class DafWeeklyEvent extends DafPageEvent {
+  get category(): string {
+    return 'Daf Weekly';
+  }
   constructor(date: HDate, daf: DafPage) {
     super(date, daf, flags.DAILY_LEARNING);
-    this.category = 'Daf Weekly';
   }
   getCategories(): string[] {
     return ['dafWeekly'];

--- a/src/DafYomiEvent.ts
+++ b/src/DafYomiEvent.ts
@@ -9,10 +9,12 @@ import './locale';
  * Event wrapper around a DafYomi instance
  */
 export class DafYomiEvent extends DafPageEvent {
+  get category(): string {
+    return 'Daf Yomi';
+  }
   constructor(date: HDate) {
     const daf = new DafYomi(date.greg());
     super(date, daf, flags.DAF_YOMI);
-    this.category = 'Daf Yomi';
   }
   /**
    * Returns Daf Yomi name including the 'Daf Yomi: ' prefix (e.g. "Daf Yomi: Pesachim 107").

--- a/src/DailyChapterEvent.ts
+++ b/src/DailyChapterEvent.ts
@@ -8,24 +8,13 @@ import './locale';
  * Event wrapper for learning where you read one chapter per day
  * used by Nach Yomi and Perek Yomi
  */
-export class DailyChapterEvent extends DailyLearningEvent {
+export abstract class DailyChapterEvent extends DailyLearningEvent {
   k: string;
   v: number;
-  private _category: string;
-  get category(): string {
-    return this._category;
-  }
-  constructor(
-    date: HDate,
-    k: string,
-    v: number,
-    category: string,
-    mask: number
-  ) {
+  constructor(date: HDate, k: string, v: number, mask: number) {
     super(date, `${k} ${v}`, mask);
     this.k = k;
     this.v = v;
-    this._category = category;
   }
   /**
    * Returns name of tractate and page (e.g. "Beitzah 21").

--- a/src/DailyChapterEvent.ts
+++ b/src/DailyChapterEvent.ts
@@ -11,7 +11,10 @@ import './locale';
 export class DailyChapterEvent extends DailyLearningEvent {
   k: string;
   v: number;
-  category: string;
+  private _category: string;
+  get category(): string {
+    return this._category;
+  }
   constructor(
     date: HDate,
     k: string,
@@ -22,7 +25,7 @@ export class DailyChapterEvent extends DailyLearningEvent {
     super(date, `${k} ${v}`, mask);
     this.k = k;
     this.v = v;
-    this.category = category;
+    this._category = category;
   }
   /**
    * Returns name of tractate and page (e.g. "Beitzah 21").

--- a/src/DailyLearningEvent.ts
+++ b/src/DailyLearningEvent.ts
@@ -6,4 +6,10 @@ export class DailyLearningEvent extends Event {
     super(date, desc, mask);
     this.alarm = false;
   }
+  /**
+   * Category name used as the location field in iCalendar event feeds.
+   */
+  get category(): string | undefined {
+    return undefined;
+  }
 }

--- a/src/DailyLearningEvent.ts
+++ b/src/DailyLearningEvent.ts
@@ -1,7 +1,7 @@
 import {HDate} from '@hebcal/hdate';
 import {Event, flags} from '@hebcal/core/dist/esm/event';
 
-export class DailyLearningEvent extends Event {
+export abstract class DailyLearningEvent extends Event {
   constructor(date: HDate, desc: string, mask: number = flags.DAILY_LEARNING) {
     super(date, desc, mask);
     this.alarm = false;

--- a/src/DailyRambam3Event.ts
+++ b/src/DailyRambam3Event.ts
@@ -45,14 +45,15 @@ export function makeDesc(readings: RambamReading[]): string {
 export class DailyRambam3Event extends DailyLearningEvent {
   readings: RambamReading[];
   events: DailyRambamEvent[];
-  category: string;
+  get category(): string {
+    return 'Daily Rambam';
+  }
   constructor(date: HDate, readings: RambamReading[]) {
     const collapsed = collapseAdjacent(readings);
     const desc = collapsed.map(r => `${r.name} ${r.perek}`).join(', ');
     super(date, desc);
     this.readings = collapsed;
     this.events = collapsed.map(r => new DailyRambamEvent(date, r));
-    this.category = 'Daily Rambam';
     if (collapsed.length > 1) {
       this.memo = this.events
         .map(ev => {

--- a/src/DailyRambamEvent.ts
+++ b/src/DailyRambamEvent.ts
@@ -10,11 +10,12 @@ import './locale';
  */
 export class DailyRambamEvent extends DailyLearningEvent {
   reading: RambamReading;
-  category: string;
+  get category(): string {
+    return 'Daily Rambam';
+  }
   constructor(date: HDate, reading: RambamReading) {
     super(date, `${reading.name} ${reading.perek}`);
     this.reading = reading;
-    this.category = 'Daily Rambam';
   }
   /**
    * Returns name of reading

--- a/src/DirshuAmudYomiEvent.ts
+++ b/src/DirshuAmudYomiEvent.ts
@@ -11,13 +11,14 @@ import './locale';
  */
 export class DirshuAmudYomiEvent extends DailyLearningEvent {
   amud: DirshuAmudYomi;
-  category: string;
+  get category(): string {
+    return 'Dirshu Amud HaYomi';
+  }
 
   constructor(date: HDate) {
     const amud = calculateDirshuAmud(date);
     super(date, `${amud.name} ${amud.amud}${amud.side}`);
     this.amud = amud;
-    this.category = 'Dirshu Amud HaYomi';
   }
 
   /**

--- a/src/KitzurShulchanAruchEvent.ts
+++ b/src/KitzurShulchanAruchEvent.ts
@@ -54,7 +54,9 @@ export class KitzurShulchanAruchEvent extends DailyLearningEvent {
   reading: KitzurShulchanAruchReading;
   optionB?: KitzurShulchanAruchReading;
   leapAdar2: boolean;
-  category: string;
+  get category(): string {
+    return BOOK_NAME;
+  }
   constructor(
     date: HDate,
     reading: KitzurShulchanAruchReading,
@@ -71,7 +73,6 @@ export class KitzurShulchanAruchEvent extends DailyLearningEvent {
     this.reading = reading;
     this.optionB = optionB;
     this.leapAdar2 = date.isLeapYear() && date.getMonth() === months.ADAR_II;
-    this.category = BOOK_NAME;
   }
   /**
    * Returns name of reading

--- a/src/MishnaYomiEvent.ts
+++ b/src/MishnaYomiEvent.ts
@@ -27,11 +27,12 @@ function formatMyomi(mishnaYomi: MishnaYomi[], locale?: string): string {
  */
 export class MishnaYomiEvent extends DailyLearningEvent {
   mishnaYomi: MishnaYomi[];
-  category: string;
+  get category(): string {
+    return 'Mishna Yomi';
+  }
   constructor(date: HDate, mishnaYomi: MishnaYomi[]) {
     super(date, formatMyomi(mishnaYomi), flags.MISHNA_YOMI);
     this.mishnaYomi = mishnaYomi;
-    this.category = 'Mishna Yomi';
   }
   /**
    * Returns Mishna Yomi name (e.g. "Bava Metzia 10:5-6" or "Berakhot 9:5-Peah 1:1").

--- a/src/NachYomiEvent.ts
+++ b/src/NachYomiEvent.ts
@@ -7,8 +7,11 @@ import {NachYomi} from './nachYomiBase';
  * Event wrapper around a Nach Yomi instance
  */
 export class NachYomiEvent extends DailyChapterEvent {
+  get category(): string {
+    return 'Nach Yomi';
+  }
   constructor(date: HDate, reading: NachYomi) {
-    super(date, reading.k, reading.v, 'Nach Yomi', flags.NACH_YOMI);
+    super(date, reading.k, reading.v, flags.NACH_YOMI);
   }
   getCategories(): string[] {
     return ['nachyomi'];

--- a/src/PerekYomiEvent.ts
+++ b/src/PerekYomiEvent.ts
@@ -7,8 +7,11 @@ import {PerekYomi} from './perekYomiBase';
  * Event wrapper around a Perek Yomi instance
  */
 export class PerekYomiEvent extends DailyChapterEvent {
+  get category(): string {
+    return 'Perek Yomi';
+  }
   constructor(date: HDate, reading: PerekYomi) {
-    super(date, reading.k, reading.v, 'Perek Yomi', flags.DAILY_LEARNING);
+    super(date, reading.k, reading.v, flags.DAILY_LEARNING);
   }
   /**
    * Returns a link to sefaria.org

--- a/src/PirkeiAvotSummerEvent.ts
+++ b/src/PirkeiAvotSummerEvent.ts
@@ -12,11 +12,12 @@ const PIRKEI_AVOT = 'Pirkei Avot';
  */
 export class PirkeiAvotSummerEvent extends DailyLearningEvent {
   reading: number[];
-  category: string;
+  get category(): string {
+    return PIRKEI_AVOT;
+  }
   constructor(date: HDate, reading: number[]) {
     super(date, PIRKEI_AVOT + ' ' + reading.join('-'));
     this.reading = reading;
-    this.category = PIRKEI_AVOT;
   }
   /**
    * Returns name of reading

--- a/src/PsalmsEvent.ts
+++ b/src/PsalmsEvent.ts
@@ -10,11 +10,12 @@ import './locale';
  */
 export class PsalmsEvent extends DailyLearningEvent {
   reading: PsalmBeginEnd;
-  category: string;
+  get category(): string {
+    return 'Psalms';
+  }
   constructor(date: HDate, reading: PsalmBeginEnd) {
     super(date, `Psalms ${reading[0]}-${reading[1]}`);
     this.reading = reading;
-    this.category = 'Psalms';
   }
   /**
    * Returns name of reading

--- a/src/SeferHaMitzvotEvent.ts
+++ b/src/SeferHaMitzvotEvent.ts
@@ -13,12 +13,13 @@ enum ReadingType {
  */
 export class SeferHaMitzvotEvent extends DailyLearningEvent {
   reading: SeferHaMitzvotReading;
-  category: string;
+  get category(): string {
+    return 'Sefer Hamitzvot';
+  }
   constructor(date: HDate, reading: SeferHaMitzvotReading) {
     const desc = `Day ${reading.day}: ${reading.reading}`;
     super(date, desc);
     this.reading = reading;
-    this.category = 'Sefer Hamitzvot';
     if (reading.note) {
       this.memo = reading.note;
     }

--- a/src/ShemiratHaLashonEvent.ts
+++ b/src/ShemiratHaLashonEvent.ts
@@ -15,8 +15,10 @@ import './locale';
 export class ShemiratHaLashonEvent extends DailyLearningEvent {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   reading: any;
-  category: string;
   memo: string;
+  get category(): string {
+    return 'Shemirat HaLashon';
+  }
   constructor(date: HDate, reading: ShemiratHaLashonReading) {
     const book = reading.bk === 1 ? 'Book I' : 'Book II';
     const section = reading.k === Chapters ? '' : `, ${reading.k}`;
@@ -24,7 +26,6 @@ export class ShemiratHaLashonEvent extends DailyLearningEvent {
     super(date, desc);
     this.reading = reading;
     this.memo = this.render('memo');
-    this.category = 'Shemirat HaLashon';
   }
   /**
    * Returns name of reading

--- a/src/TanakhYomiEvent.ts
+++ b/src/TanakhYomiEvent.ts
@@ -7,9 +7,11 @@ import {TanakhYomi} from './tanakhYomiBase';
  * Event wrapper around a tanakhYomi
  */
 export class TanakhYomiEvent extends DafPageEvent {
+  get category(): string {
+    return 'Tanakh Yomi';
+  }
   constructor(date: HDate, daf: TanakhYomi) {
     super(date, daf, flags.DAILY_LEARNING);
-    this.category = 'Tanakh Yomi';
     this.memo = daf.verses;
   }
   /**

--- a/src/YerushalmiYomiEvent.ts
+++ b/src/YerushalmiYomiEvent.ts
@@ -14,11 +14,12 @@ const vilnaMap: Record<string, (string | null)[]> = vilnaMap0;
  */
 export class YerushalmiYomiEvent extends DailyLearningEvent {
   daf: YerushalmiReading;
-  category: string;
+  get category(): string {
+    return 'Yerushalmi Yomi';
+  }
   constructor(date: HDate, daf: YerushalmiReading) {
     super(date, `${daf.name} ${daf.blatt}`, flags.YERUSHALMI_YOMI);
     this.daf = daf;
-    this.category = 'Yerushalmi Yomi';
   }
   /**
    * Returns name of tractate and page (e.g. "Yerushalmi Beitzah 21").


### PR DESCRIPTION
## Summary
Refactored the `category` property from a constructor-assigned instance field to a getter method across all daily learning event classes. This change improves code maintainability by centralizing category definitions and reducing constructor complexity.

## Key Changes
- Made `DailyLearningEvent` and `DailyChapterEvent` abstract base classes
- Converted `category` from an instance property to a getter method in `DailyLearningEvent` (returns `undefined` by default)
- Removed `category` parameter from `DailyChapterEvent` constructor
- Implemented `category` getter in all concrete event classes:
  - `ArukhHaShulchanYomiEvent`
  - `ChofetzChaimEvent`
  - `DailyRambamEvent` and `DailyRambam3Event`
  - `DirshuAmudYomiEvent`
  - `KitzurShulchanAruchEvent`
  - `MishnaYomiEvent`
  - `NachYomiEvent`
  - `PerekYomiEvent`
  - `PirkeiAvotSummerEvent`
  - `PsalmsEvent`
  - `SeferHaMitzvotEvent`
  - `ShemiratHaLashonEvent`
  - `YerushalmiYomiEvent`
  - `DafYomiEvent`, `DafWeeklyEvent`, `TanakhYomiEvent`
- Removed `category` field assignment from all constructors
- Removed unused `category` field from `DafPageEvent`

## Implementation Details
- The getter pattern allows subclasses to define their category as a constant string without requiring constructor parameters
- This reduces boilerplate in constructors and makes the category definition more discoverable in the class definition
- The base class getter returns `undefined`, allowing subclasses to optionally override it

https://claude.ai/code/session_01Pi9ATpcqnm1iHZmdAsXzBm