### PR TITLE
Add comprehensive JSDoc documentation to all public APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,59 @@ const ev = DailyLearning.lookup('dafYomi', hd);
 console.log(dt.toLocaleDateString(), hd.toString(), ev.render('en'));
 ```
 
+## Selective imports (smaller bundles)
+
+The top-level `import '@hebcal/learning'` registers *all* of the calendars
+listed above with `DailyLearning`, which pulls every cycle's lookup tables
+into your bundle. If you only need a few calendars, import them
+individually instead. Each module registers exactly one calendar (or two,
+in the case of Daf-a-Week) with `DailyLearning` as a side-effect of being
+imported, and you call them through the same `DailyLearning.lookup` API:
+
+```javascript
+import {HDate} from '@hebcal/hdate';
+import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+import '@hebcal/learning/rambam3';
+import '@hebcal/learning/dafYomi';
+
+const hd = new HDate(new Date(2024, 3, 8));
+console.log(DailyLearning.lookup('rambam3', hd).render('en'));
+console.log(DailyLearning.lookup('dafYomi', hd).render('en'));
+```
+
+The module names match the source files in `src/` (for example
+`@hebcal/learning/dafYomi`, `@hebcal/learning/rambam1`,
+`@hebcal/learning/yerushalmiYomi`, `@hebcal/learning/929`).
+Tree-shaking bundlers will then drop the unused calendars.
+
+## Low-level APIs (skip the Event wrappers)
+
+If you don't need a hebcal `Event` (with `render()`, `url()`, `memo`,
+iCalendar categories, etc.), you can call the underlying calculation
+functions directly. They accept an `HDate`, a JavaScript `Date`, or an
+absolute (R.D.) day number, and return a plain data object you can
+interpret yourself:
+
+```javascript
+import {dailyRambam3} from '@hebcal/learning/rambam3Base';
+
+// Returns an array of 3 RambamReading objects: {name, perek}
+const readings = dailyRambam3(new Date(2024, 3, 8));
+// [
+//   {name: 'Foreign Worship and Customs of the Nations', perek: 1},
+//   {name: 'Foreign Worship and Customs of the Nations', perek: 2},
+//   {name: 'Foreign Worship and Customs of the Nations', perek: 3},
+// ]
+```
+
+Each calendar's lookup function lives in its `*Base` module — for
+example `dailyRambam1`, `dailyRambam3`, `dafWeekly`, `calculate929`,
+`calculateDirshuAmud`, `arukhHaShulchanYomi`, `yerushalmiYomi`,
+`kitzurShulchanAruch`, `seferHaMitzvot`, `chofetzChaim`,
+`shemiratHaLashon`, `dailyPsalms`, `perekYomi`, `pirkeiAvot`,
+`tanakhYomi`, plus the `DafYomi`, `MishnaYomiIndex` and `NachYomiIndex`
+classes. See the per-function JSDoc for the exact return shape and the
+conditions under which a function throws (date before the cycle began,
+invalid date type) or returns `null` (no reading on this date).
+
 ## [API Documentation](https://hebcal.github.io/api/learning/index.html)

--- a/src/929Event.ts
+++ b/src/929Event.ts
@@ -6,9 +6,25 @@ import {isHebrewLocale} from './common';
 import './locale';
 
 /**
- * Event wrapper for a daily 929 Tanach chapter reading.
- * Each event corresponds to one Bible chapter in the 929 program
- * (https://www.929.org.il).
+ * Event wrapper for a daily 929 Tanakh chapter reading
+ * (https://www.929.org.il). The 929 Project reads one chapter of the
+ * Hebrew Bible Sun-Thu (skipping Fri/Sat), covering all 929 chapters
+ * in about 3.5 years.
+ *
+ * The first cycle began on Sunday, **21 December 2014**
+ * (29 Kislev 5775). `DailyLearning.lookup('929', hd)` returns `null`
+ * on Fridays and Saturdays (skip days), on the wind-down days
+ * between the end of one cycle and the start of the next, and on any
+ * date before 21 December 2014.
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/929';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784 (Mon)
+ * const ev = DailyLearning.lookup('929', hd);
+ * console.log(ev.render('en'));  // => "Malachi 3 (567)"
  */
 export class Nine29Event extends DailyLearningEvent {
   reading: Nine29Reading;

--- a/src/ArukhHaShulchanYomiEvent.ts
+++ b/src/ArukhHaShulchanYomiEvent.ts
@@ -6,7 +6,23 @@ import {gematriyaNN, isHebrewLocale} from './common';
 import './locale';
 
 /**
- * Event wrapper around a Arukh HaShulchan Yomi reading
+ * Event wrapper around an {@link AhSYomiReading Arukh HaShulchan Yomi
+ * reading}.
+ *
+ * The cycle began on Friday, **29 May 2020** (6 Sivan 5780) and
+ * completes the entire Arukh HaShulchan in 1,719 days. Looking up a
+ * date earlier than that returns `null` from
+ * `DailyLearning.lookup('arukhHaShulchanYomi', ...)`.
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/arukhHaShulchanYomi';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784
+ * const ev = DailyLearning.lookup('arukhHaShulchanYomi', hd);
+ * console.log(ev.render('en'));
+ * // => "Yoreh De'ah 263:4-10"
  */
 export class ArukhHaShulchanYomiEvent extends DailyLearningEvent {
   reading: AhSYomiReading;

--- a/src/ChofetzChaimEvent.ts
+++ b/src/ChofetzChaimEvent.ts
@@ -12,7 +12,24 @@ import {
 import './locale';
 
 /**
- * Event wrapper around a Chofetz Chaim instance
+ * Event wrapper around a Sefer Chofetz Chaim reading — daily study
+ * of the Jewish ethics and laws of speech by Rabbi Yisrael Meir
+ * Kagan.
+ *
+ * The schedule is Hebrew-calendar driven and repeats on a 3-year
+ * cycle; the published cycle began on **1 Tishrei 5634**
+ * (~22 September 1873). Looking up a date earlier than that returns
+ * `null` from `DailyLearning.lookup('chofetzChaim', ...)`.
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/chofetzChaim';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784
+ * const ev = DailyLearning.lookup('chofetzChaim', hd);
+ * console.log(ev.render('en'));
+ * // => "Hilchos LH 10.4"
  */
 export class ChofetzChaimEvent extends DailyLearningEvent {
   reading: ChofetzChaimReading;

--- a/src/DafPageEvent.ts
+++ b/src/DafPageEvent.ts
@@ -20,7 +20,15 @@ export const dafYomiSefaria: Record<string, string> = {
 } as const;
 
 /**
- * Event wrapper around a DafPage instance
+ * Abstract event wrapper around any kind of Talmud page ({@link DafPage}),
+ * shared by {@link DafYomiEvent}, {@link DafWeeklyEvent}, and
+ * {@link TanakhYomiEvent}. Holds the `daf` (tractate name + page number)
+ * and provides default `render`, `renderBrief`, and `url` implementations
+ * that produce sefaria.org or dafyomi.org links.
+ *
+ * Subclasses override `category`, `getCategories()`, and—where the
+ * display format differs—`render`/`url`. Not instantiated directly;
+ * use {@link DafYomiEvent}, {@link DafWeeklyEvent}, etc.
  */
 export abstract class DafPageEvent extends DailyLearningEvent {
   daf: DafPage;

--- a/src/DafWeeklyEvent.ts
+++ b/src/DafWeeklyEvent.ts
@@ -4,7 +4,26 @@ import {DafPage} from './DafPage';
 import {DafPageEvent} from './DafPageEvent';
 
 /**
- * Event wrapper around a daily weekly
+ * Event wrapper around the **Daf-a-Week** Talmud page — the same
+ * `daf` is repeated each day of the week.
+ *
+ * The cycle began on Sunday, **6 March 2005** (25 Adar I 5765).
+ * Looking up a date earlier than that returns `null` from
+ * `DailyLearning.lookup('dafWeekly', ...)`.
+ *
+ * Two calendars use this event: `dafWeekly` (every day of the week)
+ * and `dafWeeklySunday` (only on Sundays — `lookup` returns `null` on
+ * Mon-Sat).
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/dafWeekly';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784
+ * const ev = DailyLearning.lookup('dafWeekly', hd);
+ * console.log(ev.render('en'));
+ * // => "Ketubot 83"
  */
 export class DafWeeklyEvent extends DafPageEvent {
   get category(): string {

--- a/src/DafYomiEvent.ts
+++ b/src/DafYomiEvent.ts
@@ -6,7 +6,22 @@ import {DafYomi} from './dafYomiBase';
 import './locale';
 
 /**
- * Event wrapper around a DafYomi instance
+ * Event wrapper around a {@link DafYomi} instance — one daily page of
+ * the Babylonian Talmud.
+ *
+ * The cycle began on **11 September 1923** (1 Tishrei 5684).
+ * Looking up a date earlier than that returns `null` from
+ * `DailyLearning.lookup('dafYomi', ...)`.
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/dafYomi';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784
+ * const ev = DailyLearning.lookup('dafYomi', hd);
+ * console.log(ev.render('en'));
+ * // => "Daf Yomi: Baba Metzia 40"
  */
 export class DafYomiEvent extends DafPageEvent {
   get category(): string {

--- a/src/DailyChapterEvent.ts
+++ b/src/DailyChapterEvent.ts
@@ -5,8 +5,15 @@ import {isHebrewLocale} from './common';
 import './locale';
 
 /**
- * Event wrapper for learning where you read one chapter per day
- * used by Nach Yomi and Perek Yomi
+ * Abstract base class for daily learning where each day's reading is
+ * a single "book + chapter" reference — used by {@link NachYomiEvent}
+ * (chapters of Nevi'im and Ketuvim) and {@link PerekYomiEvent}
+ * (chapters of the Mishna).
+ *
+ * Stores the book/tractate name as `k` and the chapter number as `v`,
+ * and produces a Sefaria URL of the form
+ * `https://www.sefaria.org/{book}.{chapter}?lang=bi`. Not instantiated
+ * directly.
  */
 export abstract class DailyChapterEvent extends DailyLearningEvent {
   k: string;

--- a/src/DailyLearningEvent.ts
+++ b/src/DailyLearningEvent.ts
@@ -1,6 +1,23 @@
 import {HDate} from '@hebcal/hdate';
 import {Event, flags} from '@hebcal/core/dist/esm/event';
 
+/**
+ * Abstract base class for all daily-learning events produced by this package
+ * (Daf Yomi, Mishna Yomi, Daily Rambam, 929, etc.).
+ *
+ * Concrete subclasses are returned by `DailyLearning.lookup(name, hdate)`
+ * once the corresponding calendar has been registered (either via the
+ * top-level `import '@hebcal/learning'` or a per-calendar import such as
+ * `import '@hebcal/learning/dafYomi'`). Subclasses extend the
+ * hebcal `Event` API with calendar-specific fields (e.g. `daf`, `reading`,
+ * `readings`, `mishnaYomi`) and typically override `render(locale)` and
+ * `url()`.
+ *
+ * Events created by this package have `alarm` set to `false` (these are
+ * study readings, not appointments) and carry the `DAILY_LEARNING` event
+ * flag — some subclasses use a more specific flag (`DAF_YOMI`,
+ * `NACH_YOMI`, `MISHNA_YOMI`, `YERUSHALMI_YOMI`) instead.
+ */
 export abstract class DailyLearningEvent extends Event {
   constructor(date: HDate, desc: string, mask: number = flags.DAILY_LEARNING) {
     super(date, desc, mask);
@@ -8,6 +25,8 @@ export abstract class DailyLearningEvent extends Event {
   }
   /**
    * Category name used as the location field in iCalendar event feeds.
+   * Subclasses override this with their calendar's display name
+   * (e.g. "Daf Yomi", "Daily Rambam", "929").
    */
   get category(): string | undefined {
     return undefined;

--- a/src/DailyRambam3Event.ts
+++ b/src/DailyRambam3Event.ts
@@ -40,7 +40,24 @@ export function makeDesc(readings: RambamReading[]): string {
 }
 
 /**
- * Event wrapper around a Daily Rambam instance
+ * Event wrapper for the Mishneh Torah's **3-chapters-a-day** cycle.
+ * Each event groups the three chapters studied that day, collapsing
+ * adjacent chapters in the same section into a single range
+ * (e.g. "Human Dispositions 1-2") for display.
+ *
+ * The cycle began on Sunday, **29 April 1984** (27 Nisan 5744) and
+ * repeats every 339 days. Looking up a date earlier than that returns
+ * `null` from `DailyLearning.lookup('rambam3', ...)`.
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/rambam3';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784
+ * const ev = DailyLearning.lookup('rambam3', hd);
+ * console.log(ev.render('en'));
+ * // => "Foreign Worship and Customs of the Nations 1-3"
  */
 export class DailyRambam3Event extends DailyLearningEvent {
   readings: RambamReading[];

--- a/src/DailyRambamEvent.ts
+++ b/src/DailyRambamEvent.ts
@@ -6,7 +6,25 @@ import {gematriyaNN, isHebrewLocale} from './common';
 import './locale';
 
 /**
- * Event wrapper around a Daily Rambam instance
+ * Event wrapper around a single chapter from the Mishneh Torah, as
+ * scheduled by Maimonides' Daily Rambam **1-chapter-a-day** cycle.
+ *
+ * The cycle began on Sunday, **29 April 1984** (27 Nisan 5744) and
+ * repeats every 1,017 days. Looking up a date earlier than that
+ * returns `null` from `DailyLearning.lookup('rambam1', ...)`.
+ *
+ * The companion {@link DailyRambam3Event} covers the 3-chapter-a-day
+ * variant of the same cycle.
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/rambam1';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784
+ * const ev = DailyLearning.lookup('rambam1', hd);
+ * console.log(ev.render('en'));
+ * // => "Appraisals and Devoted Property 5"
  */
 export class DailyRambamEvent extends DailyLearningEvent {
   reading: RambamReading;

--- a/src/DirshuAmudYomiEvent.ts
+++ b/src/DirshuAmudYomiEvent.ts
@@ -7,7 +7,23 @@ import {isHebrewLocale} from './common';
 import './locale';
 
 /**
- * Event wrapper around a Dirshu Amud HaYomi result
+ * Event wrapper around a Dirshu Amud HaYomi reading — one amud
+ * (half-page) of the Babylonian Talmud per day, roughly twice as slow
+ * as the standard Daf Yomi.
+ *
+ * The cycle began on Monday, **16 October 2023** (1 Cheshvan 5784).
+ * Looking up a date earlier than that returns `null` from
+ * `DailyLearning.lookup('dirshuAmudYomi', ...)`.
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/dirshuAmudYomi';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784
+ * const ev = DailyLearning.lookup('dirshuAmudYomi', hd);
+ * console.log(ev.render('en'));
+ * // => "Dirshu Amud HaYomi: Shabbat 27a"
  */
 export class DirshuAmudYomiEvent extends DailyLearningEvent {
   amud: DirshuAmudYomi;

--- a/src/KitzurShulchanAruchEvent.ts
+++ b/src/KitzurShulchanAruchEvent.ts
@@ -47,8 +47,28 @@ function renderReading(
 }
 
 /**
- * Event wrapper for
- * Pirkei Avot being studied on Shabbat between Pesach and Rosh Hashana
+ * Event wrapper around a Kitzur Shulchan Aruch Yomi reading — daily
+ * study of Rabbi Shlomo Ganzfried's 1864 summary of the Shulchan
+ * Aruch.
+ *
+ * The schedule is Hebrew-calendar driven and repeats annually, so
+ * there is no fixed cycle start. The lookup returns `null` from
+ * `DailyLearning.lookup('kitzurShulchanAruch', ...)` on the two dates
+ * that have no entry in the table: **30 Cheshvan** and **30 Adar I**.
+ *
+ * During Adar II of a leap year, both replacement tracks
+ * (Hilchot Shmita v'Terumah and Hilchot Brachot v'Tefilah) are
+ * carried on the event — see the `reading` and `optionB` fields.
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/kitzurShulchanAruch';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784
+ * const ev = DailyLearning.lookup('kitzurShulchanAruch', hd);
+ * console.log(ev.render('en'));
+ * // => "Hilchot Shmita v'Terumah 71-75 / Hilchot Brachot v'Tefilah 57:2-E"
  */
 export class KitzurShulchanAruchEvent extends DailyLearningEvent {
   reading: KitzurShulchanAruchReading;

--- a/src/MishnaYomiEvent.ts
+++ b/src/MishnaYomiEvent.ts
@@ -23,7 +23,22 @@ function formatMyomi(mishnaYomi: MishnaYomi[], locale?: string): string {
 }
 
 /**
- * Event wrapper around a Mishna Yomi instance
+ * Event wrapper around a Mishna Yomi reading — the two consecutive
+ * mishnayot studied each day.
+ *
+ * The cycle began on **20 May 1947** (1 Sivan 5707).
+ * Looking up a date earlier than that returns `null` from
+ * `DailyLearning.lookup('mishnaYomi', ...)`.
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/mishnaYomi';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784
+ * const ev = DailyLearning.lookup('mishnaYomi', hd);
+ * console.log(ev.render('en'));
+ * // => "Nazir 1:6-7"
  */
 export class MishnaYomiEvent extends DailyLearningEvent {
   mishnaYomi: MishnaYomi[];

--- a/src/NachYomiEvent.ts
+++ b/src/NachYomiEvent.ts
@@ -4,7 +4,22 @@ import {DailyChapterEvent} from './DailyChapterEvent';
 import {NachYomi} from './nachYomiBase';
 
 /**
- * Event wrapper around a Nach Yomi instance
+ * Event wrapper around a Nach Yomi reading — one chapter from
+ * Nevi'im or Ketuvim per day.
+ *
+ * The current cycle began on **1 November 2007** (20 Cheshvan 5768).
+ * Looking up a date earlier than that returns `null` from
+ * `DailyLearning.lookup('nachYomi', ...)`.
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/nachYomi';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784
+ * const ev = DailyLearning.lookup('nachYomi', hd);
+ * console.log(ev.render('en'));
+ * // => "I Samuel 23"
  */
 export class NachYomiEvent extends DailyChapterEvent {
   get category(): string {

--- a/src/PerekYomiEvent.ts
+++ b/src/PerekYomiEvent.ts
@@ -4,7 +4,22 @@ import {DailyChapterEvent} from './DailyChapterEvent';
 import {PerekYomi} from './perekYomiBase';
 
 /**
- * Event wrapper around a Perek Yomi instance
+ * Event wrapper around a Perek Yomi reading — one chapter of the
+ * Mishna studied each day.
+ *
+ * The cycle began on Shabbat, **9 February 2002** (27 Sh'vat 5762).
+ * Looking up a date earlier than that returns `null` from
+ * `DailyLearning.lookup('perekYomi', ...)`.
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/perekYomi';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784
+ * const ev = DailyLearning.lookup('perekYomi', hd);
+ * console.log(ev.render('en'));
+ * // => "Sotah 8"
  */
 export class PerekYomiEvent extends DailyChapterEvent {
   get category(): string {

--- a/src/PirkeiAvotSummerEvent.ts
+++ b/src/PirkeiAvotSummerEvent.ts
@@ -7,8 +7,22 @@ import './locale';
 const PIRKEI_AVOT = 'Pirkei Avot';
 
 /**
- * Event wrapper for
- * Pirkei Avot being studied on Shabbat between Pesach and Rosh Hashana
+ * Event wrapper for Pirkei Avot ("Ethics of the Fathers"), studied
+ * one chapter on each Shabbat of the summer between Passover and
+ * Rosh Hashana.
+ *
+ * The schedule is computed from the Hebrew calendar each year, with
+ * no fixed start date. `DailyLearning.lookup('pirkeiAvotSummer', hd)`
+ * returns `null` outside that window (and on every non-Shabbat).
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/pirkeiAvotSummer';
+ *
+ * const hd = new HDate(new Date(2024, 6, 6));  // 30 Sivan 5784 (Sat)
+ * const ev = DailyLearning.lookup('pirkeiAvotSummer', hd);
+ * console.log(ev.render('en'));  // => "Pirkei Avot 4"
  */
 export class PirkeiAvotSummerEvent extends DailyLearningEvent {
   reading: number[];

--- a/src/PsalmsEvent.ts
+++ b/src/PsalmsEvent.ts
@@ -6,7 +6,22 @@ import {isHebrewLocale} from './common';
 import './locale';
 
 /**
- * Event wrapper around a daily Psalms / Tehillim
+ * Event wrapper around the daily Psalms / Tehillim portion in the
+ * traditional 30-day cycle. The cycle is indexed by Hebrew day of
+ * the month and repeats every Hebrew month, so any Hebrew date
+ * returns a reading and `DailyLearning.lookup('psalms', hd)` never
+ * returns `null`.
+ *
+ * On 29-day months, the 30th portion is combined with the 29th.
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/psalms';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784
+ * const ev = DailyLearning.lookup('psalms', hd);
+ * console.log(ev.render('en'));  // => "Psalms 140-150"
  */
 export class PsalmsEvent extends DailyLearningEvent {
   reading: PsalmBeginEnd;

--- a/src/SeferHaMitzvotEvent.ts
+++ b/src/SeferHaMitzvotEvent.ts
@@ -9,7 +9,23 @@ enum ReadingType {
 }
 
 /**
- * Event wrapper around a Sefer HaMitzvot reading
+ * Event wrapper around a Sefer Hamitzvos (Daily Mitzvah by Rambam)
+ * reading.
+ *
+ * The cycle began on Sunday, **29 April 1984** (27 Nisan 5744) and
+ * repeats every 339 days. Looking up a date earlier than that returns
+ * `null` from `DailyLearning.lookup('seferHaMitzvot', ...)`.
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/seferHaMitzvot';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784
+ * const ev = DailyLearning.lookup('seferHaMitzvot', hd);
+ * console.log(ev.render('en'));
+ * // => "Day 13: Negative Commandment 10, 47, 60, 6, 5, 2, 3, 4, 15;
+ * //    Positive Commandment 186; Negative Commandment 23, 24"
  */
 export class SeferHaMitzvotEvent extends DailyLearningEvent {
   reading: SeferHaMitzvotReading;

--- a/src/ShemiratHaLashonEvent.ts
+++ b/src/ShemiratHaLashonEvent.ts
@@ -10,7 +10,24 @@ import {
 import './locale';
 
 /**
- * Event wrapper around a Sefer Shemirat HaLashon instance
+ * Event wrapper around a Sefer Shemirat HaLashon reading — daily
+ * study of the laws of guarded speech by Rabbi Yisrael Meir Kagan
+ * (a companion to the Chofetz Chaim).
+ *
+ * The schedule is Hebrew-calendar driven and repeats annually; the
+ * published cycle began on **21 Sh'vat 5636** (~16 February 1876).
+ * Looking up a date earlier than that returns `null` from
+ * `DailyLearning.lookup('shemiratHaLashon', ...)`.
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/shemiratHaLashon';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784
+ * const ev = DailyLearning.lookup('shemiratHaLashon', hd);
+ * console.log(ev.render('en'));
+ * // => "Book I, Shar Hatorah 7.7-7.8"
  */
 export class ShemiratHaLashonEvent extends DailyLearningEvent {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/TanakhYomiEvent.ts
+++ b/src/TanakhYomiEvent.ts
@@ -4,7 +4,21 @@ import {DafPageEvent} from './DafPageEvent';
 import {TanakhYomi} from './tanakhYomiBase';
 
 /**
- * Event wrapper around a tanakhYomi
+ * Event wrapper around a Tanakh Yomi seder reading.
+ *
+ * The cycle began on **26 October 1948** (23 Tishrei 5709). It skips
+ * Shabbat and major festivals, so `DailyLearning.lookup('tanakhYomi',
+ * hd)` returns `null` on those days as well as on any date before the
+ * cycle began.
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/tanakhYomi';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784
+ * const ev = DailyLearning.lookup('tanakhYomi', hd);
+ * console.log(ev.render('en'));  // => "Ezekiel Seder 3"
  */
 export class TanakhYomiEvent extends DafPageEvent {
   get category(): string {

--- a/src/YerushalmiYomiEvent.ts
+++ b/src/YerushalmiYomiEvent.ts
@@ -10,7 +10,32 @@ import vilnaMap0 from './yerushalmiVilnaMap.json';
 const vilnaMap: Record<string, (string | null)[]> = vilnaMap0;
 
 /**
- * Event wrapper around a Yerushalmi Yomi result
+ * Event wrapper around a Yerushalmi (Jerusalem Talmud) Daf Yomi
+ * reading. Used by both the `yerushalmi-vilna` and
+ * `yerushalmi-schottenstein` calendars; the `daf.ed` field
+ * distinguishes them.
+ *
+ * Cycle start dates:
+ *  - **Vilna**: Shabbat, **2 February 1980** (15 Sh'vat 5740). Skips
+ *    Yom Kippur and Tish'a B'Av, so `lookup` returns `null` on those
+ *    days.
+ *  - **Schottenstein**: Monday, **14 November 2022** (20 Cheshvan
+ *    5783). Does not skip fast days.
+ *
+ * Looking up a date earlier than the relevant start date returns
+ * `null`.
+ *
+ * @example
+ * import {HDate} from '@hebcal/hdate';
+ * import {DailyLearning} from '@hebcal/core/dist/esm/DailyLearning';
+ * import '@hebcal/learning/yerushalmiYomi';
+ *
+ * const hd = new HDate(new Date(2024, 3, 8));  // 29 Adar II 5784
+ * const vilna = DailyLearning.lookup('yerushalmi-vilna', hd);
+ * console.log(vilna.render('en'));  // => "Yerushalmi Eruvin 25"
+ *
+ * const schott = DailyLearning.lookup('yerushalmi-schottenstein', hd);
+ * console.log(schott.render('en'));  // => "Yerushalmi Terumot 97"
  */
 export class YerushalmiYomiEvent extends DailyLearningEvent {
   daf: YerushalmiReading;

--- a/src/arukhHaShulchanYomiBase.ts
+++ b/src/arukhHaShulchanYomiBase.ts
@@ -29,7 +29,23 @@ const sections = [
 ];
 
 /**
- * Calculates Arukh HaShulchan Yomi
+ * Calculates the Arukh HaShulchan Yomi reading for the given date.
+ *
+ * Daily study of the Arukh HaShulchan, a work of halacha written by
+ * Yechiel Michel Epstein. The current cycle began on Friday,
+ * **29 May 2020** (6 Sivan 5780) and completes the entire Arukh
+ * HaShulchan in 1,719 days (~4 years 8 months), then repeats
+ * indefinitely.
+ *
+ * @param date - Hebrew date, Gregorian `Date`, or absolute (R.D.) day
+ *   number.
+ * @returns An {@link AhSYomiReading} `{k, v}` describing the section
+ *   and verse range for that day. Always returns a reading once the
+ *   cycle has begun (the schedule has no skip days).
+ * @throws {RangeError} if `date` is before 29 May 2020 (the start of
+ *   the cycle).
+ * @throws {TypeError} if `date` is not an `HDate`, `Date`, or finite
+ *   number.
  */
 export function arukhHaShulchanYomi(
   date: HDate | Date | number

--- a/src/chofetzChaimBase.ts
+++ b/src/chofetzChaimBase.ts
@@ -365,11 +365,40 @@ const leap = [
   [[10, Shvat, 19, Iyyar, 29, Elul], Tziyurim, 10, 11],
 ];
 
+/**
+ * Describes one day's reading in the Sefer Chofetz Chaim calendar.
+ */
 export type ChofetzChaimReading = {
+  /**
+   * Book/section code. One of `"Hakdamah"` (Preface), `"Psichah"`
+   * (Opening Comments), `"Lavin"` (Negative Commandments), `"Asin"`
+   * (Positive Commandments), `"Arurin"` (Curses), `"HilchosLH"`
+   * (Part One — Lashon Hara), `"HilchosRechilus"` (Part Two —
+   * Rechilut), or `"Tziyurim"` (Illustrations). Translate via the
+   * `englishNames` map exported from this module.
+   */
   k: string;
+  /**
+   * Beginning of the day's reading. A halacha/principle number for
+   * the introductory sections (e.g. `1` for Hakdamah halacha 1), or
+   * a `principle.halacha` style number for HilchosLH/Rechilus
+   * (e.g. `1.1`).
+   */
   b: string | number;
+  /**
+   * End of the day's reading. Same format as `b`. May be an array
+   * (a few entries in the Hakdamah section study several distinct
+   * halachas), or may equal `b` when only one halacha is studied.
+   */
   e: string | number | number[];
+  /**
+   * Optional Hebrew incipit ("opening words") of the day's text,
+   * used by some calendar consumers as a study aid.
+   */
   textBegin?: string;
+  /**
+   * Optional Hebrew explicit ("closing words") of the day's text.
+   */
   textEnd?: string;
 };
 
@@ -383,7 +412,26 @@ type Entry = [
 ];
 
 /**
- * Looks up Chofetz Chaim Calendar for date
+ * Returns the Sefer Chofetz Chaim reading scheduled for the given
+ * Hebrew date.
+ *
+ * Sefer Chofetz Chaim (Rabbi Yisrael Meir Kagan, published 1873)
+ * covers the Jewish ethics and laws of speech. The schedule is
+ * Hebrew-calendar driven: the same Hebrew date in different years
+ * receives the same reading, in a 3-year mini-cycle that repeats. The
+ * implementation handles short Cheshvan and short Kislev by folding
+ * the missing 30th day's reading into the 29th.
+ *
+ * Unlike most other calendars in this package, this function only
+ * accepts an `HDate` (not a Gregorian `Date` or absolute day number).
+ *
+ * @param hdate - Hebrew date to look up.
+ * @returns A {@link ChofetzChaimReading} for the given date. Always
+ *   returns a reading once the cycle has begun; there are no skip
+ *   days.
+ * @throws {RangeError} if `hdate` is before 1 Tishrei 5634
+ *   (~22 September 1873).
+ * @throws {TypeError} if `hdate` is not an `HDate`.
  */
 export function chofetzChaim(hdate: HDate): ChofetzChaimReading {
   if (!HDate.isHDate(hdate)) {

--- a/src/dafWeeklyBase.ts
+++ b/src/dafWeeklyBase.ts
@@ -9,8 +9,21 @@ export const dafWeeklyStart = greg.greg2abs(startDate);
 const numDays = 2711 * 7;
 
 /**
- * Daf-a-Week
- * @param date - Hebrew or Gregorian date
+ * Calculates the **Daf-a-Week** Talmud page for the given date.
+ *
+ * In this slower schedule the same daf is studied for an entire week;
+ * one full cycle through the Babylonian Talmud takes ~52 years. The
+ * cycle began on Sunday, **6 March 2005** (25 Adar I 5765).
+ *
+ * @param date - Hebrew date, Gregorian `Date`, or absolute (R.D.) day
+ *   number. The function returns the same {@link DafPage} for any day
+ *   of the same week; the `dafWeeklySunday` calendar registered with
+ *   `DailyLearning` exposes only the Sunday occurrence.
+ * @returns A {@link DafPage} for that week (`name` + `blatt`). Never
+ *   `null` once the cycle has begun.
+ * @throws {RangeError} if `date` is before 6 March 2005.
+ * @throws {TypeError} if `date` is not an `HDate`, `Date`, or finite
+ *   number.
  */
 export function dafWeekly(date: HDate | Date | number): DafPage {
   const abs = getAbsDate(date);

--- a/src/dafYomiBase.ts
+++ b/src/dafYomiBase.ts
@@ -144,12 +144,34 @@ export function findDaf(shas: Daf[], dno: number): DafPage {
 }
 
 /**
- * Returns the Daf Yomi for given date
+ * The Babylonian Talmud page (daf) studied on a given date in the
+ * worldwide Daf Yomi cycle.
+ *
+ * The original ("old") cycle began on **11 September 1923**
+ * (1 Tishrei 5684); the current page numbering ("new" cycle)
+ * starts from 24 June 1975. Each cycle takes approximately 7½ years
+ * to complete the entire Talmud.
+ *
+ * Use this class when you want just the tractate name and page number
+ * (a {@link DafPage} subclass with `name` and `blatt` fields) without
+ * the surrounding {@link DafYomiEvent} wrapper.
+ *
+ * @throws {RangeError} from the constructor if `date` is before
+ *   11 September 1923.
+ * @throws {TypeError} from the constructor if `date` is not an
+ *   `HDate`, `Date`, or finite number.
+ *
+ * @example
+ * import {DafYomi} from '@hebcal/learning/dafYomiBase';
+ *
+ * const daf = new DafYomi(new Date(2024, 3, 8));
+ * console.log(daf.getName(), daf.getBlatt());  // "Baba Metzia" 40
  */
 export class DafYomi extends DafPage {
   /**
-   * Initializes a daf yomi instance
-   * @param date Gregorian or Hebrew date
+   * Computes the Daf Yomi for the given date.
+   * @param date - Hebrew date, Gregorian `Date`, or absolute (R.D.)
+   *   day number.
    */
   constructor(date: HDate | Date | number) {
     const d = calculateDaf(date);

--- a/src/dirshuAmudYomiBase.ts
+++ b/src/dirshuAmudYomiBase.ts
@@ -58,17 +58,36 @@ export const shas: AmudEntry[] = (
 const totalAmudim = shas.reduce((s, a) => s + a.amudim, 0);
 
 /**
- * Represents an amud (side of a page) in the Dirshu Amud HaYomi program
+ * One amud (side of a page) of the Babylonian Talmud as scheduled by
+ * the Dirshu Amud HaYomi program.
  */
 export type DirshuAmudYomi = {
+  /** Tractate name in Sephardic transliteration (e.g. `"Berachot"`,
+   *  `"Baba Metzia"`). */
   name: string;
+  /** Page number (daf), starting from `2` for the first amud of each
+   *  tractate (the convention used for Talmud Bavli citations). */
   amud: number;
+  /** Side of the page: `"a"` (recto) or `"b"` (verso). */
   side: 'a' | 'b';
 };
 
 /**
- * Calculates the Dirshu Amud HaYomi for a given date
- * @param date - Hebrew or Gregorian date
+ * Calculates the Dirshu Amud HaYomi for a given date — one amud
+ * (half-page) of the Babylonian Talmud per day, taking roughly twice
+ * as long as the standard Daf Yomi cycle.
+ *
+ * The cycle began on Monday, **16 October 2023** (1 Cheshvan 5784)
+ * and continues indefinitely, restarting from Berachot 2a after the
+ * final amud of Niddah.
+ *
+ * @param date - Hebrew date, Gregorian `Date`, or absolute (R.D.) day
+ *   number.
+ * @returns A {@link DirshuAmudYomi} `{name, amud, side}`. Never
+ *   `null`; the cycle has no skip days.
+ * @throws {RangeError} if `date` is before 16 October 2023.
+ * @throws {TypeError} if `date` is not an `HDate`, `Date`, or finite
+ *   number.
  */
 export function calculateDirshuAmud(
   date: HDate | Date | number

--- a/src/kitzurShulchanAruchBase.ts
+++ b/src/kitzurShulchanAruchBase.ts
@@ -2,12 +2,21 @@ import {HDate, months} from '@hebcal/hdate';
 import kitzurSaJson from './kitzurSa.json';
 
 /**
- * Describes a daily reading of the Kitzur Shulchan Aruch
+ * Describes one day's reading in the Kitzur Shulchan Aruch calendar.
  */
 export type KitzurShulchanAruchReading = {
-  /** begin */
+  /**
+   * Beginning of the day's reading. A `siman:seif` reference like
+   * `"5:1"` (chapter 5, paragraph 1). On Klalim/leap-option days the
+   * value may be a non-numeric token (e.g. `"Klalim"`, `"Shmita"`).
+   */
   b: string;
-  /** end */
+  /**
+   * End of the day's reading in the same `siman:seif` format, or
+   * `undefined` if the day covers only a single paragraph. May end in
+   * `:E` ("end of siman") to indicate the reading runs to the last
+   * paragraph of the begin-siman.
+   */
   e: string | undefined;
 };
 
@@ -45,9 +54,28 @@ function getMonthName(hd: HDate, leapOption: 'A' | 'B'): IdxName {
 }
 
 /**
- * Calculates Kitzur Shulchan Aruch Yomi.
- * Kitzur Shulchan Aruch is a summary of the Shulchan Aruch of Rabbi Yosef Karo.
- * It was authored by Rabbi Shlomo Ganzfried in 1864.
+ * Returns the Kitzur Shulchan Aruch Yomi reading for the given date.
+ *
+ * The Kitzur Shulchan Aruch is a summary of the Shulchan Aruch of
+ * Rabbi Yosef Karo, authored by Rabbi Shlomo Ganzfried in 1864. The
+ * schedule is Hebrew-calendar driven and repeats each year, so there
+ * is no fixed cycle start; any Hebrew date returns a reading (with
+ * the exceptions noted below).
+ *
+ * During Adar II of a leap year there is no part of the regular
+ * cycle to study, so two replacement tracks are offered: `'A'` —
+ * Hilchot Shmita v'Terumah (the default), or `'B'` — Hilchot Brachot
+ * v'Tefilah.
+ *
+ * @param date - Hebrew date, Gregorian `Date`, or absolute (R.D.) day
+ *   number.
+ * @param leapOption - Which Adar II track to follow when `date` falls
+ *   in Adar II of a leap year. Ignored on all other dates.
+ * @returns A {@link KitzurShulchanAruchReading} `{b, e}`, or
+ *   `undefined` for the two dates that have no entry in the table:
+ *   **30 Cheshvan** and **30 Adar I**.
+ * @throws {TypeError} (indirectly, via the `HDate` constructor) if
+ *   `date` is not an `HDate`, `Date`, or finite number.
  */
 export function kitzurShulchanAruch(
   date: HDate | Date | number,

--- a/src/mishnaYomiBase.ts
+++ b/src/mishnaYomiBase.ts
@@ -19,13 +19,28 @@ export type MishnaYomi = {
 };
 
 /**
- * A program of daily learning in which participants study two Mishnahs
- * each day in order to finish the entire Mishnah in ~6 years.
+ * A program of daily learning in which participants study two
+ * mishnayot each day in order to finish the entire Mishna in ~6 years.
+ *
+ * The cycle began on **20 May 1947** (1 Sivan 5707).
+ *
+ * Construct the index once and call {@link MishnaYomiIndex.lookup
+ * .lookup(date)} for each day you need.
+ *
+ * @example
+ * import {MishnaYomiIndex} from '@hebcal/learning/mishnaYomiBase';
+ *
+ * const index = new MishnaYomiIndex();
+ * const reading = index.lookup(new Date(2024, 3, 8));
+ * // [{k: 'Nazir', v: '1:6'}, {k: 'Nazir', v: '1:7'}]
  */
 export class MishnaYomiIndex {
   private days: MishnaYomi[][];
   /**
-   * Initializes a Mishna Yomi instance
+   * Builds the in-memory index of all 2,096 days in the cycle.
+   * Construction walks every mishna in the Shisha Sidrei; reuse the
+   * same instance across many lookups instead of constructing on each
+   * call.
    */
   constructor() {
     const tmp = Array<MishnaYomi>(numMishnayot);
@@ -49,7 +64,17 @@ export class MishnaYomiIndex {
   }
 
   /**
-   * Looks up a Mishna Yomi
+   * Returns the two mishnayot to study on the given date.
+   *
+   * @param date - Hebrew date, Gregorian `Date`, or absolute (R.D.)
+   *   day number.
+   * @returns An array of exactly two {@link MishnaYomi} entries. The
+   *   two mishnayot are usually consecutive within the same tractate
+   *   but can straddle a tractate boundary on the last day of a
+   *   tractate.
+   * @throws {RangeError} if `date` is before 20 May 1947.
+   * @throws {TypeError} if `date` is not an `HDate`, `Date`, or
+   *   finite number.
    */
   lookup(date: HDate | Date | number): MishnaYomi[] {
     const abs = getAbsDate(date);

--- a/src/nachYomiBase.ts
+++ b/src/nachYomiBase.ts
@@ -21,13 +21,28 @@ export type NachYomi = {
 };
 
 /**
- * A daily regimen of learning the books of Nevi'im (Prophets)
- * and Ketuvim (Writings).
+ * A daily regimen of learning the books of Nevi'im (Prophets) and
+ * Ketuvim (Writings), one chapter per day.
+ *
+ * The current cycle began on **1 November 2007** (20 Cheshvan 5768)
+ * and completes Nach in 742 days (~2 years), then repeats
+ * indefinitely.
+ *
+ * Construct the index once and call {@link NachYomiIndex.lookup
+ * .lookup(date)} for each day you need.
+ *
+ * @example
+ * import {NachYomiIndex} from '@hebcal/learning/nachYomiBase';
+ *
+ * const index = new NachYomiIndex();
+ * console.log(index.lookup(new Date(2024, 3, 8)));
+ * // {k: 'I Samuel', v: 23}
  */
 export class NachYomiIndex {
   private days: NachYomi[];
   /**
-   * Initializes a Nach Yomi instance
+   * Builds the in-memory index of all 742 chapters in the cycle.
+   * Reuse the same instance across many lookups.
    */
   constructor() {
     const days = Array<NachYomi>(numChapters);
@@ -43,7 +58,15 @@ export class NachYomiIndex {
   }
 
   /**
-   * Looks up a Nach Yomi
+   * Returns the chapter of Nach to study on the given date.
+   *
+   * @param date - Hebrew date, Gregorian `Date`, or absolute (R.D.)
+   *   day number.
+   * @returns A {@link NachYomi} `{k, v}` — book name and chapter
+   *   number. Never `null`; the cycle has no skip days.
+   * @throws {RangeError} if `date` is before 1 November 2007.
+   * @throws {TypeError} if `date` is not an `HDate`, `Date`, or
+   *   finite number.
    */
   lookup(date: HDate | Date | number): NachYomi {
     const abs = getAbsDate(date);

--- a/src/perekYomiBase.ts
+++ b/src/perekYomiBase.ts
@@ -11,17 +11,31 @@ const startDate = new Date(2002, 1, 9);
 export const perekYomiStart = greg.greg2abs(startDate);
 
 /**
- * Describes a chapter to be read
+ * One chapter of the Mishna as scheduled by the Perek Yomi cycle.
  */
 export type PerekYomi = {
-  /** book name in English transliteration (e.g. "Joshua", "Song of Songs") */
+  /** Mishna tractate name in Sephardic transliteration
+   *  (e.g. "Berakhot", "Sotah", "Avot") */
   k: string;
-  /** chapter number (e.g. 2) */
+  /** 1-based chapter number within the tractate */
   v: number;
 };
 
 /**
- * Calculates Perek Yomi (Mishnah, one chapter per day)
+ * Calculates the Perek Yomi (Mishna, **one chapter per day**)
+ * reading for the given date.
+ *
+ * The cycle began on Shabbat, **9 February 2002** (27 Sh'vat 5762)
+ * and completes the entire Mishna in 525 days (~17 months), then
+ * repeats indefinitely.
+ *
+ * @param date - Hebrew date, Gregorian `Date`, or absolute (R.D.) day
+ *   number.
+ * @returns A {@link PerekYomi} `{k, v}` — tractate name and chapter
+ *   number. Never `null`; the cycle has no skip days.
+ * @throws {RangeError} if `date` is before 9 February 2002.
+ * @throws {TypeError} if `date` is not an `HDate`, `Date`, or finite
+ *   number.
  */
 export function perekYomi(date: HDate | Date | number): PerekYomi {
   const cday = getAbsDate(date);

--- a/src/pirkeiAvotBase.ts
+++ b/src/pirkeiAvotBase.ts
@@ -1,19 +1,31 @@
 import {HDate, months} from '@hebcal/hdate';
 
 /**
- * Pirkei Avot being studied on Shabbat between Pesach and Rosh Hashana
+ * Returns the Pirkei Avot chapter(s) studied on the given Shabbat,
+ * or `null` if the date is not a Pirkei Avot Shabbat.
  *
- * "From at least the time of Saadia Gaon (10th century),
- * it has been customary to study one chapter a week on each Shabbat
- * between Passover and Shavuot; today, the tractate is generally studied
- * on each Shabbat of the summer, from Passover to Rosh Hashanah,
- * the entire cycle repeating a few times with doubling of chapters
- * at the end if there are not a perfect multiple of six weeks"
- * https://en.wikipedia.org/wiki/Pirkei_Avot#Study_of_the_work
+ * "From at least the time of Saadia Gaon (10th century), it has been
+ * customary to study one chapter a week on each Shabbat between
+ * Passover and Shavuot; today, the tractate is generally studied on
+ * each Shabbat of the summer, from Passover to Rosh Hashanah, the
+ * entire cycle repeating a few times with doubling of chapters at
+ * the end if there are not a perfect multiple of six weeks"
+ * (https://en.wikipedia.org/wiki/Pirkei_Avot#Study_of_the_work).
  *
- * returns array (since it can return 2 chapters) or undefined if there is no Pirkei Avot on that day
- * optimized for diaspora and il
- * feel free to modify whatever you want, i am sure this task can be done in different ways and orders
+ * Unlike most other calendars in this package, this one is purely
+ * computed from the Hebrew calendar — there is no fixed start date,
+ * just a recurring seasonal window. It never throws on a
+ * pre-cycle-start date; it returns `null` for any date outside the
+ * window described below.
+ *
+ * @param dt - Hebrew or Gregorian date to look up.
+ * @param il - `true` for the Israel schedule (no 8th day Pesach,
+ *   no 2nd day Shavuot); `false` for the Diaspora schedule.
+ * @returns An array of one or two chapter numbers (1-6), or `null`
+ *   if `dt` is **not** a Shabbat, is before Pesach, is after Rosh
+ *   Hashana, or coincides with a holiday on which Pirkei Avot is
+ *   skipped (8th day Pesach / 2nd day Shavuot in the Diaspora; Erev
+ *   Tish'a B'Av or Tish'a B'Av).
  */
 export function pirkeiAvot(dt: Date | HDate, il: boolean): number[] | null {
   const hd = new HDate(dt);

--- a/src/psalmsBase.ts
+++ b/src/psalmsBase.ts
@@ -1,5 +1,12 @@
 import {HDate} from '@hebcal/hdate';
 
+/**
+ * One day's slice of the 30-day Psalms cycle, as a two-element tuple
+ * `[begin, end]`. Both entries are normally chapter numbers (e.g.
+ * `[10, 17]`), but Psalm 119 — the longest chapter, studied over two
+ * days — uses verse-prefixed strings (`"119:1"`/`"119:96"` and
+ * `"119:97"`/`"119:176"`).
+ */
 export type PsalmBeginEnd = [number | string, number | string];
 
 const schedule: PsalmBeginEnd[] = [
@@ -37,7 +44,24 @@ const schedule: PsalmBeginEnd[] = [
 ];
 
 /**
- * Calculates Daily Psalms (Tehillim) for 30-day cycle.
+ * Returns the Daily Psalms (Tehillim) portion for the given date,
+ * using the traditional 30-day cycle indexed by Hebrew day of the
+ * month.
+ *
+ * The entire book is completed on the final day of each Hebrew
+ * month. In months with only 29 days, the 30th portion is combined
+ * with the 29th (so 29 Cheshvan or 29 Kislev may return
+ * `[140, 150]`).
+ *
+ * Unlike most calendars in this package there is no fixed cycle
+ * start — any Hebrew date returns a reading. The function never
+ * returns `null`.
+ *
+ * @param date - Hebrew date, Gregorian `Date`, or absolute (R.D.) day
+ *   number.
+ * @returns A {@link PsalmBeginEnd} tuple `[begin, end]`.
+ * @throws {TypeError} (indirectly, via the `HDate` constructor) if
+ *   `date` is not an `HDate`, `Date`, or finite number.
  */
 export function dailyPsalms(date: HDate | Date | number): PsalmBeginEnd {
   const hd = new HDate(date);

--- a/src/rambam1Base.ts
+++ b/src/rambam1Base.ts
@@ -29,13 +29,46 @@ const first4verses = [
   ['1:1-4:8', '5:1-9:9', '10:1-14:10'], // Overview of Mishneh Torah Contents
 ];
 
+/**
+ * One section/chapter of the Mishneh Torah, as scheduled by the Daily
+ * Rambam cycle.
+ */
 export type RambamReading = {
+  /**
+   * English transliteration of the section name (Halacha) within the
+   * Mishneh Torah, e.g. `"Foundations of the Torah"`, `"Sabbath"`,
+   * `"Kings and Wars"`. The first four entries (`"Transmission of the
+   * Oral Law"`, `"Positive Mitzvot"`, `"Negative Mitzvot"`, `"Overview
+   * of Mishneh Torah Contents"`) refer to the Book of Mitzvot rather
+   * than a numbered chapter.
+   */
   name: string;
+  /**
+   * Chapter number (perek). Usually a `number`, but can be a string
+   * range like `"4-5"` when adjacent chapters are combined into one
+   * day, or a verse range like `"1:1-4:8"` for the introductory
+   * sections of the Mishneh Torah where the schedule covers a span
+   * of mitzvot rather than chapters.
+   */
   perek: number | string;
 };
 
 /**
- * Calculates Daily Rambam (Mishneh Torah) for 1 chapter a day cycle.
+ * Calculates the Daily Rambam (Mishneh Torah) reading for the
+ * **1 chapter a day** cycle.
+ *
+ * The cycle began on Sunday, 27 Nisan 5744 (29 April 1984) and
+ * completes one pass through the Mishneh Torah every 1,017 days
+ * (~2 years 9 months). The cycle then repeats indefinitely.
+ *
+ * @param date - Hebrew date, Gregorian `Date`, or absolute (R.D.) day
+ *   number.
+ * @returns The {@link RambamReading} for the given date — a single
+ *   `{name, perek}` object.
+ * @throws {RangeError} if `date` is before 29 April 1984 (the start of
+ *   the cycle).
+ * @throws {TypeError} if `date` is not an `HDate`, `Date`, or finite
+ *   number.
  */
 export function dailyRambam1(date: HDate | Date | number): RambamReading {
   const cday = getAbsDate(date);

--- a/src/rambam3Base.ts
+++ b/src/rambam3Base.ts
@@ -23,7 +23,28 @@ mishnehTorah3[15].ch = 5;
 mishnehTorah3[20].ch = 8;
 
 /**
- * Calculates Daily Rambam (Mishneh Torah) for 3 chapters a day cycle.
+ * Calculates the Daily Rambam (Mishneh Torah) reading for the
+ * **3 chapters a day** cycle.
+ *
+ * The cycle shares its 29 April 1984 start date with the
+ * {@link dailyRambam1 1-chapter cycle} but completes the entire
+ * Mishneh Torah in 339 days (~11 months) — about three times faster.
+ * The cycle differs from the 1-chapter schedule in two places to keep
+ * the three daily chapters logically grouped: "The Order of Prayer"
+ * has an extra day, and the final two chapters of "Leavened and
+ * Unleavened Bread" are combined into a single day.
+ *
+ * @param date - Hebrew date, Gregorian `Date`, or absolute (R.D.) day
+ *   number.
+ * @returns An array of exactly three {@link RambamReading} objects, in
+ *   the order they are studied during the day. Adjacent readings may
+ *   share a `name` when all three chapters fall within the same
+ *   section of the Mishneh Torah; the {@link DailyRambam3Event}
+ *   wrapper collapses these for display.
+ * @throws {RangeError} if `date` is before 29 April 1984 (the start of
+ *   the cycle).
+ * @throws {TypeError} if `date` is not an `HDate`, `Date`, or finite
+ *   number.
  */
 export function dailyRambam3(date: HDate | Date | number): RambamReading[] {
   const cday = getAbsDate(date);

--- a/src/seferHaMitzvotBase.ts
+++ b/src/seferHaMitzvotBase.ts
@@ -3,11 +3,25 @@ import {checkTooEarly, getAbsDate} from './common';
 import seferHaMitzvotJson from './seferHaMitzvot.json';
 
 /**
- * Describes a daily reading of the Sefer Hamitzvos
+ * One day's reading in the Sefer Hamitzvos (Daily Mitzvah) calendar.
  */
 export type SeferHaMitzvotReading = {
+  /** 1-based day number within the 339-day cycle. */
   day: number;
+  /**
+   * The day's mitzvah list, encoded as a single comma-separated
+   * string of Maimonides' mitzvah references (e.g. `"P186, N10, N47"`
+   * — `P` = Positive Commandment, `N` = Negative Commandment). The
+   * {@link SeferHaMitzvotEvent} `render()` method expands this for
+   * display.
+   */
   reading: string;
+  /**
+   * Optional explanatory note. Present only on the handful of days
+   * (140, 161, 258, 259) where editions of the Sefer Hamitzvot
+   * Schedule disagree about which mitzvah is studied; the note
+   * describes the alternative.
+   */
   note?: string;
 };
 
@@ -33,7 +47,22 @@ function getNote(day: number): string | undefined {
 }
 
 /**
- * Calculates Daily Mitzvah (Rambam) from Sefer Hamitzvos
+ * Returns the Sefer Hamitzvos (Daily Mitzvah) reading for the given
+ * date.
+ *
+ * Daily study of one of Maimonides' 613 mitzvot, grouped into a
+ * 339-day cycle that completes the entire Sefer Hamitzvos. The cycle
+ * began on Sunday, **29 April 1984** (27 Nisan 5744) and repeats
+ * indefinitely.
+ *
+ * @param date - Hebrew date, Gregorian `Date`, or absolute (R.D.) day
+ *   number.
+ * @returns A {@link SeferHaMitzvotReading} `{day, reading, note?}`.
+ *   Always returns a reading once the cycle has begun; there are no
+ *   skip days.
+ * @throws {RangeError} if `date` is before 29 April 1984.
+ * @throws {TypeError} if `date` is not an `HDate`, `Date`, or finite
+ *   number.
  */
 export function seferHaMitzvot(
   date: HDate | Date | number

--- a/src/shemiratHaLashonBase.ts
+++ b/src/shemiratHaLashonBase.ts
@@ -437,15 +437,56 @@ const schedule: Entry[] = [
   [[29, Elul], [29, Elul], Book2, Epilogue, 4.1, 4.2],
 ];
 
+/**
+ * Describes one day's reading in the Sefer Shemirat HaLashon calendar.
+ */
 export type ShemiratHaLashonReading = {
+  /**
+   * Book number — `1` for Book I (Sha'ar HaZechira / HaTvuna /
+   * HaTorah / Epilogue) or `2` for Book II (numbered chapters).
+   */
   bk: number;
+  /**
+   * Section name. For Book I one of `"Hakdamah"`, `"Shar Hazechira"`,
+   * `"Shar Hatvuna"`, `"Shar Hatorah"`, or `"Chasimas Hasefer"`
+   * (Epilogue). For Book II this is always `"x"` (a sentinel meaning
+   * "no sub-section"). Translate via the `englishNames` map exported
+   * from this module.
+   */
   k: string;
+  /**
+   * Beginning of the day's reading — usually a `chapter.halacha`
+   * number (e.g. `1.1`) but occasionally a plain integer for sections
+   * that aren't subdivided into halachot.
+   */
   b: number | string;
+  /**
+   * End of the day's reading. Same format as `b`. Equals `b` when
+   * only one halacha is studied.
+   */
   e: number | string;
 };
 
 /**
- * Looks up Sefer Shemirat HaLashon Calendar for date
+ * Returns the Sefer Shemirat HaLashon reading scheduled for the
+ * given Hebrew date.
+ *
+ * Sefer Shemirat HaLashon (Rabbi Yisrael Meir Kagan, completed 1876)
+ * is a companion volume to the Chofetz Chaim. Like its companion the
+ * schedule is Hebrew-calendar driven: the same Hebrew date in
+ * different years receives the same reading, with separate tracks
+ * for common and leap years. Short Cheshvan and short Kislev fold
+ * the missing 30th day's reading into the 29th.
+ *
+ * Unlike most other calendars in this package, this function only
+ * accepts an `HDate` (not a Gregorian `Date` or absolute day number).
+ *
+ * @param hdate - Hebrew date to look up.
+ * @returns A {@link ShemiratHaLashonReading} for the given date.
+ *   Always returns a reading once the cycle has begun.
+ * @throws {RangeError} if `hdate` is before 21 Sh'vat 5636
+ *   (~16 February 1876).
+ * @throws {TypeError} if `hdate` is not an `HDate`.
  */
 export function shemiratHaLashon(hdate: HDate): ShemiratHaLashonReading {
   if (!HDate.isHDate(hdate)) {

--- a/src/tanakhYomiBase.ts
+++ b/src/tanakhYomiBase.ts
@@ -64,8 +64,27 @@ const toSkip = new Set([
 ]);
 
 /**
- * Calculates Tanakh Yomi.
- * @param date - Hebrew or Gregorian date
+ * Calculates the Tanakh Yomi reading for the given date.
+ *
+ * Tanakh Yomi is a learning cycle for completing Tanakh annually
+ * according to the ancient Masoretic division of sedarim. The cycle
+ * began on **26 October 1948** (23 Tishrei 5709) and repeats each
+ * Hebrew year, starting on 23 Tishrei (the day after Shmini Atzeret
+ * in Israel).
+ *
+ * The schedule skips Shabbat and the major festivals (Pesach 1/7,
+ * Shavuot, Rosh Hashana, Yom Kippur, Sukkot 1, Shmini Atzeret,
+ * Purim, Yom HaAtzma'ut, Tish'a B'Av).
+ *
+ * @param date - Hebrew date, Gregorian `Date`, or absolute (R.D.) day
+ *   number.
+ * @returns A {@link TanakhYomi} (a {@link DafPage} subclass) for the
+ *   reading day, or `null` on Shabbat and on any of the skipped
+ *   holidays listed above. The `verses` property holds the Masoretic
+ *   verse range.
+ * @throws {RangeError} if `date` is before 26 October 1948.
+ * @throws {TypeError} if `date` is not an `HDate`, `Date`, or finite
+ *   number.
  */
 export function tanakhYomi(date: HDate | Date | number): TanakhYomi | null {
   const hd: HDate = HDate.isHDate(date) ? (date as HDate) : new HDate(date);
@@ -242,13 +261,20 @@ function makeReadingTable(year: number): ReadingsForYear {
 }
 
 /**
- * Returns the Daf Yomi for given date
+ * One day's reading in the Tanakh Yomi cycle — a single Masoretic
+ * seder (verse range) within one of the books of Tanakh.
+ *
+ * Inherits {@link DafPage}'s `name` (book) and `blatt` (seder
+ * number); the `verses` property is set to the verse range string
+ * (e.g. `"Joshua 1:1-9"`) consumed by the wrapper event's URL
+ * builder.
  */
 export class TanakhYomi extends DafPage {
   /**
-   * Initializes a daf yomi instance
-   * @param name
-   * @param blatt
+   * Builds a TanakhYomi for the given book and seder number.
+   * Throws if `(name, blatt)` is not a valid seder in the Masoretic
+   * table — call {@link tanakhYomi} to compute the right values from
+   * a date instead of constructing directly.
    */
   constructor(name: string, blatt: number | string) {
     super(name, blatt);

--- a/src/yerushalmiBase.ts
+++ b/src/yerushalmiBase.ts
@@ -1,12 +1,34 @@
 import {HDate, greg, months} from '@hebcal/hdate';
 import {checkTooEarly, getAbsDate} from './common';
 
+/**
+ * Description of one Yerushalmi (Jerusalem Talmud) Daf Yomi
+ * configuration — currently the {@link vilna Vilna} and
+ * {@link schottenstein Schottenstein} editions.
+ *
+ * Pass an instance of this to {@link yerushalmiYomi} to compute the
+ * page for a given date. Each edition has its own page numbering and
+ * its own historical start date, so the two cycles do not line up.
+ */
 export type YerushalmiYomiConfig = {
+  /** Edition identifier — `"vilna"` or `"schottenstein"`. Surfaces
+   *  on {@link YerushalmiReading.ed}. */
   ed: string;
+  /** First day of the cycle as a JavaScript `Date`. */
   startDate: Date;
+  /** First day of the cycle as an absolute (R.D.) day number — the
+   *  Gregorian start date converted via `greg.greg2abs()`. */
   startAbs: number;
+  /** Whether to skip Yom Kippur and Tish'a B'Av (true for Vilna,
+   *  false for Schottenstein, per each edition's published custom). */
   skipYK9Av: boolean;
+  /** Ordered list of tractates in the cycle, each as
+   *  `[name, numDapim]`. */
   shas: [string, number][];
+  /** Total number of dapim in the cycle. Computed and cached on
+   *  first call to {@link yerushalmiYomi}; the literal `0` in the
+   *  exported {@link vilna}/{@link schottenstein} constants is a
+   *  placeholder. */
   numDapim: number;
 };
 
@@ -121,9 +143,18 @@ export const schottenstein: YerushalmiYomiConfig = {
 const SUN = 0;
 const SAT = 6;
 
+/**
+ * One day's Daf Yomi Yerushalmi reading.
+ */
 export type YerushalmiReading = {
+  /** Tractate name in Sephardic transliteration (e.g. `"Berakhot"`,
+   *  `"Peah"`, `"Yevamot"`). */
   name: string;
+  /** Page number (daf) within the tractate, 1-based. */
   blatt: number;
+  /** Edition identifier — `"vilna"` or `"schottenstein"`. Copied from
+   *  the {@link YerushalmiYomiConfig.ed config.ed} used in the
+   *  lookup. */
   ed: string;
 };
 
@@ -157,22 +188,28 @@ export function cycleStart(config: YerushalmiYomiConfig, cday: number): number {
 }
 
 /**
- * Using the Vilna edition, the Yerushalmi Daf Yomi program takes
- * ~4.25 years or 51 months.
- * Unlike the Daf Yomi Bavli cycle, this Yerushalmi cycle skips both
- * Yom Kippur and Tisha B'Av (returning `null`).
- * The page numbers are according to the Vilna
- * Edition which is used since 1900.
+ * Calculates the Daf Yomi Yerushalmi (Jerusalem Talmud) reading for
+ * the given date.
  *
- * The Schottenstein edition uses different page numbers and takes
- * ~6 years to complete.
+ * Using the {@link vilna Vilna} edition the cycle takes ~4.25 years
+ * (51 months) and skips both Yom Kippur and Tish'a B'Av. The
+ * {@link schottenstein Schottenstein} edition uses different page
+ * numbers, takes ~6 years to complete, and **does not** skip those
+ * fast days.
  *
- * Throws an exception if the date is before Daf Yomi Yerushalmi
- * cycle began (2 February 1980 for Vilna,
- * 14 November 2022 for Schottenstein).
- *
- * @param date - Hebrew or Gregorian date
- * @param config - either vilna or schottenstein
+ * @param date - Hebrew date, Gregorian `Date`, or absolute (R.D.) day
+ *   number.
+ * @param config - Either {@link vilna} or {@link schottenstein} (or
+ *   any other config matching the {@link YerushalmiYomiConfig}
+ *   shape).
+ * @returns A {@link YerushalmiReading} `{name, blatt, ed}`, or
+ *   `null` on Yom Kippur and Tish'a B'Av when using the Vilna config
+ *   (`skipYK9Av === true`).
+ * @throws {Error} if `config` is missing or has no `shas` array.
+ * @throws {RangeError} if `date` is before the cycle's start
+ *   (2 February 1980 for Vilna; 14 November 2022 for Schottenstein).
+ * @throws {TypeError} if `date` is not an `HDate`, `Date`, or finite
+ *   number.
  */
 export function yerushalmiYomi(
   date: HDate | Date | number,


### PR DESCRIPTION
This PR adds detailed JSDoc comments to all public types, functions, and classes throughout the learning package, significantly improving API documentation and IDE support.

## Summary
Every public export now includes comprehensive JSDoc documentation with:
- Clear descriptions of purpose and behavior
- `@param` and `@returns` tags with type information
- `@throws` tags documenting error conditions
- `@example` blocks showing typical usage patterns
- Cross-references to related types and functions via `@link` tags

## Key Changes

**Type Documentation:**
- Added JSDoc to all exported type definitions (`YerushalmiYomiConfig`, `YerushalmiReading`, `ChofetzChaimReading`, `ShemiratHaLashonReading`, `KitzurShulchanAruchReading`, `RambamReading`, `MishnaYomi`, `NachYomi`, `PerekYomi`, `SeferHaMitzvotReading`, `DirshuAmudYomi`, `PsalmBeginEnd`, `TanakhYomi`)
- Documented each field with its purpose, format, and constraints

**Function Documentation:**
- Enhanced all calculation functions (`yerushalmiYomi`, `chofetzChaim`, `shemiratHaLashon`, `kitzurShulchanAruch`, `tanakhYomi`, `dailyRambam1`, `dailyRambam3`, `pirkeiAvot`, `seferHaMitzvot`, `dafWeekly`, `arukhHaShulchanYomi`, `dirshuAmud`, `perekYomi`, `psalms`)
- Added parameter descriptions, return types, and error conditions
- Included practical usage examples for most functions

**Class Documentation:**
- Added JSDoc to all event wrapper classes (`DafYomiEvent`, `YerushalmiYomiEvent`, `MishnaYomiEvent`, `NachYomiEvent`, `PerekYomiEvent`, `DafWeeklyEvent`, `TanakhYomiEvent`, `DailyRambamEvent`, `DailyRambam3Event`, `ChofetzChaimEvent`, `ShemiratHaLashonEvent`, `KitzurShulchanAruchEvent`, `SeferHaMitzvotEvent`, `ArukhHaShulchanYomiEvent`, `DirshuAmudYomiEvent`, `PirkeiAvotSummerEvent`, `PsalmsEvent`, `929Event`)
- Added JSDoc to index classes (`MishnaYomiIndex`, `NachYomiIndex`)
- Documented constructor behavior and key methods

**README Updates:**
- Added new "Selective imports (smaller bundles)" section explaining how to import individual calendars for tree-shaking
- Added new "Low-level APIs (skip the Event wrappers)" section documenting direct access to calculation functions without Event wrappers
- Provided practical examples for both patterns

## Notable Details
- All cycle start dates are now documented with specific dates and Hebrew calendar references
- Error conditions (RangeError, TypeError) are explicitly documented for each function
- Cross-references between related calendars (e.g., rambam1 ↔ rambam3) are included
- Examples use consistent formatting and realistic dates (29 Adar II 5784 / 8 April 2024)
- Documentation clarifies which functions accept HDate vs Date vs absolute day numbers

https://claude.ai/code/session_01Xo3rASt4zEDMtwhj3nNqqG