### PR TITLE
refactor: extract sefariaUrl helper to common.ts

### DIFF
--- a/src/929Event.ts
+++ b/src/929Event.ts
@@ -2,7 +2,7 @@ import {HDate, gematriya} from '@hebcal/hdate';
 import {Locale} from '@hebcal/core/dist/esm/locale';
 import {Nine29Reading} from './929Base';
 import {DailyLearningEvent} from './DailyLearningEvent';
-import {isHebrewLocale} from './common';
+import {isHebrewLocale, sefariaUrl} from './common';
 import './locale';
 
 /**
@@ -65,8 +65,7 @@ export class Nine29Event extends DailyLearningEvent {
    * e.g. https://www.sefaria.org/Deuteronomy.34?lang=bi
    */
   url(): string {
-    const bookSlug = this.reading.book.replaceAll(' ', '_');
-    return `https://www.sefaria.org/${bookSlug}.${this.reading.bookChap}?lang=bi`;
+    return sefariaUrl(this.reading.book, this.reading.bookChap);
   }
 
   getCategories(): string[] {

--- a/src/DafPageEvent.ts
+++ b/src/DafPageEvent.ts
@@ -1,6 +1,7 @@
 import {HDate} from '@hebcal/hdate';
 import {DailyLearningEvent} from './DailyLearningEvent';
 import {DafPage} from './DafPage';
+import {sefariaUrl} from './common';
 import shekalimDafYomiMap0 from './shekalimDafYomiMap.json';
 import './locale';
 
@@ -65,11 +66,10 @@ export abstract class DafPageEvent extends DailyLearningEvent {
       const aStart = aEntry.split('-')[0];
       const bEnd = bEntry.includes('-') ? bEntry.split('-')[1] : bEntry;
       const ref = `${aStart}-${bEnd}`.replaceAll(':', '.');
-      return `https://www.sefaria.org/Jerusalem_Talmud_Shekalim.${ref}?lang=bi`;
+      return sefariaUrl('Jerusalem Talmud Shekalim', ref);
     } else {
       const name0 = dafYomiSefaria[tractate] || tractate;
-      const name = name0.replaceAll(' ', '_');
-      return `https://www.sefaria.org/${name}.${blatt}a?lang=bi`;
+      return sefariaUrl(name0, `${blatt}a`);
     }
   }
 }

--- a/src/DailyChapterEvent.ts
+++ b/src/DailyChapterEvent.ts
@@ -1,7 +1,7 @@
 import {HDate, gematriya} from '@hebcal/hdate';
 import {Locale} from '@hebcal/core/dist/esm/locale';
 import {DailyLearningEvent} from './DailyLearningEvent';
-import {isHebrewLocale} from './common';
+import {isHebrewLocale, sefariaUrl} from './common';
 import './locale';
 
 /**
@@ -39,9 +39,7 @@ export abstract class DailyChapterEvent extends DailyLearningEvent {
    * Returns a link to sefaria.org
    */
   url(): string {
-    const name = this.k.replaceAll(' ', '_');
-    const chapter = this.v;
-    return `https://www.sefaria.org/${name}.${chapter}?lang=bi`;
+    return sefariaUrl(this.k, this.v);
   }
   getCategories(): string[] {
     return ['unknown'];

--- a/src/DirshuAmudYomiEvent.ts
+++ b/src/DirshuAmudYomiEvent.ts
@@ -3,7 +3,7 @@ import {HDate, gematriya} from '@hebcal/hdate';
 import {dafYomiSefaria, shekalimDafYomiMap} from './DafPageEvent';
 import {DailyLearningEvent} from './DailyLearningEvent';
 import {DirshuAmudYomi, calculateDirshuAmud} from './dirshuAmudYomiBase';
-import {isHebrewLocale} from './common';
+import {isHebrewLocale, sefariaUrl} from './common';
 import './locale';
 
 /**
@@ -82,11 +82,10 @@ export class DirshuAmudYomiEvent extends DailyLearningEvent {
     if (tractate === 'Shekalim') {
       const entry = shekalimDafYomiMap[`${amud.amud}${amud.side}`];
       const ref = entry.replaceAll(':', '.');
-      return `https://www.sefaria.org/Jerusalem_Talmud_Shekalim.${ref}?lang=bi`;
+      return sefariaUrl('Jerusalem Talmud Shekalim', ref);
     }
     const name0 = dafYomiSefaria[tractate] || tractate;
-    const name = name0.replaceAll(' ', '_');
-    return `https://www.sefaria.org/${name}.${amud.amud}${amud.side}?lang=bi`;
+    return sefariaUrl(name0, `${amud.amud}${amud.side}`);
   }
 
   getCategories(): string[] {

--- a/src/TanakhYomiEvent.ts
+++ b/src/TanakhYomiEvent.ts
@@ -2,6 +2,7 @@ import {HDate} from '@hebcal/hdate';
 import {flags} from '@hebcal/core/dist/esm/event';
 import {DafPageEvent} from './DafPageEvent';
 import {TanakhYomi} from './tanakhYomiBase';
+import {sefariaUrl} from './common';
 
 /**
  * Event wrapper around a Tanakh Yomi seder reading.
@@ -34,9 +35,9 @@ export class TanakhYomiEvent extends DafPageEvent {
   url(): string {
     const memo: string = this.daf.verses!;
     const space = memo.lastIndexOf(' ');
-    const book = memo.substring(0, space).replaceAll(' ', '_');
+    const book = memo.substring(0, space);
     const verses = memo.substring(space + 1).replaceAll(':', '.');
-    return `https://www.sefaria.org/${book}.${verses}?lang=bi`;
+    return sefariaUrl(book, verses);
   }
   getCategories(): string[] {
     return ['tanakhYomi'];

--- a/src/YerushalmiYomiEvent.ts
+++ b/src/YerushalmiYomiEvent.ts
@@ -3,7 +3,7 @@ import {HDate} from '@hebcal/hdate';
 import {flags} from '@hebcal/core/dist/esm/event';
 import {DailyLearningEvent} from './DailyLearningEvent';
 import {YerushalmiReading} from './yerushalmiBase';
-import {gematriyaNN, isHebrewLocale} from './common';
+import {gematriyaNN, isHebrewLocale, sefariaUrl} from './common';
 import './locale';
 import vilnaMap0 from './yerushalmiVilnaMap.json';
 
@@ -85,9 +85,8 @@ export class YerushalmiYomiEvent extends DailyLearningEvent {
       return undefined;
     }
     const name0 = 'Jerusalem Talmud ' + tractate;
-    const name = name0.replaceAll(' ', '_');
     const verses = verses0.replaceAll(':', '.');
-    return `https://www.sefaria.org/${name}.${verses}?lang=bi`;
+    return sefariaUrl(name0, verses);
   }
   getCategories(): string[] {
     return ['yerushalmi', this.daf.ed];

--- a/src/common.ts
+++ b/src/common.ts
@@ -57,3 +57,13 @@ export function gematriyaNN(num: number | string): string {
 export function isHebrewLocale(locale: string): boolean {
   return locale === 'he' || locale === 'he-x-nonikud';
 }
+
+/**
+ * Builds a Sefaria URL of the form
+ * `https://www.sefaria.org/{book}.{chapter}?lang=bi`.
+ * Spaces in `book` are converted to underscores automatically.
+ */
+export function sefariaUrl(book: string, chapter: number | string): string {
+  const slug = book.replaceAll(' ', '_');
+  return `https://www.sefaria.org/${slug}.${chapter}?lang=bi`;
+}


### PR DESCRIPTION
Add sefariaUrl(book, chapter) to common.ts that handles the standard
Sefaria URL pattern (spaces→underscores, ?lang=bi suffix).
chapter is typed number|string to cover plain chapter numbers,
amud suffixes like '23a', and verse ranges like '3.5-4.2'.

Apply it across all six callers that used the identical pattern:
DailyChapterEvent, 929Event, TanakhYomiEvent, YerushalmiYomiEvent,
DafPageEvent (both Shekalim and standard branches), DirshuAmudYomiEvent.

Files using encodeURIComponent (Rambam, Chofetz Chaim, etc.) and
prefix-based slugs (Pirkei_/Mishnah_) are intentionally left alone
as they are genuinely different patterns.

https://claude.ai/code/session_01W9qSdWUh6EdV2eYJ9rafUV